### PR TITLE
Docs: refer to threading.current_thread instead of deprecated currentThread

### DIFF
--- a/py3.10/doc/processing-ref.html
+++ b/py3.10/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/py3.10/doc/processing-ref.txt
+++ b/py3.10/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/py3.11/doc/processing-ref.html
+++ b/py3.11/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/py3.11/doc/processing-ref.txt
+++ b/py3.11/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/py3.7/doc/processing-ref.html
+++ b/py3.7/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/py3.7/doc/processing-ref.txt
+++ b/py3.7/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/py3.8/doc/processing-ref.html
+++ b/py3.8/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/py3.8/doc/processing-ref.txt
+++ b/py3.8/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/py3.9/doc/processing-ref.html
+++ b/py3.9/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/py3.9/doc/processing-ref.txt
+++ b/py3.9/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/pypy3.7/doc/processing-ref.html
+++ b/pypy3.7/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/pypy3.7/doc/processing-ref.txt
+++ b/pypy3.7/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/pypy3.8/doc/processing-ref.html
+++ b/pypy3.8/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/pypy3.8/doc/processing-ref.txt
+++ b/pypy3.8/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 

--- a/pypy3.9/doc/processing-ref.html
+++ b/pypy3.9/doc/processing-ref.html
@@ -272,7 +272,7 @@ which have already finished.</p>
 <dd>Returns the number of CPUs in the system.  May raise
 <tt class="docutils literal"><span class="pre">NotImplementedError</span></tt>.</dd>
 <dt><tt class="docutils literal"><span class="pre">currentProcess()</span></tt></dt>
-<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.currentThread()</span></tt>.</p>
+<dd><p class="first">An analogue of <tt class="docutils literal"><span class="pre">threading.current_thread()</span></tt>.</p>
 <p class="last">Returns the object corresponding to the current process.</p>
 </dd>
 <dt><tt class="docutils literal"><span class="pre">freezeSupport()</span></tt></dt>

--- a/pypy3.9/doc/processing-ref.txt
+++ b/pypy3.9/doc/processing-ref.txt
@@ -286,7 +286,7 @@ Miscellaneous
         `NotImplementedError`.
 
     `currentProcess()`
-        An analogue of `threading.currentThread()`.
+        An analogue of `threading.current_thread()`.
 
         Returns the object corresponding to the current process.
 


### PR DESCRIPTION
`threading.currentThread` was deprecated in Python 3.10 (October 2021) and will be removed in Python 3.12 (October 2023).

Let's refer instead to `threading.current_thread`, it's been around since Python 2.6 (October 2008).

* https://docs.python.org/3.12/whatsnew/3.10.html#deprecated
* https://github.com/python/cpython/pull/25174
