### PR TITLE
Don't try to import a toplevel __init__ module

### DIFF
--- a/py3.10/multiprocess/tests/mp_preload.py
+++ b/py3.10/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.10/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.10/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.10/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.10/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.10/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.10/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.11/multiprocess/tests/mp_preload.py
+++ b/py3.11/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.11/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.11/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.11/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.11/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.11/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.11/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.12/multiprocess/tests/mp_preload.py
+++ b/py3.12/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.12/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.12/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.12/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.12/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.12/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.12/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.7/multiprocess/tests/mp_preload.py
+++ b/py3.7/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocess.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.7/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.7/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.7/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.7/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -8,9 +8,9 @@ if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
 if sys.platform == "win32":
-    raise unittest.SkipTest("fork is not available on Windows")
+    raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.7/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.7/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.8/multiprocess/tests/mp_preload.py
+++ b/py3.8/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.8/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.8/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.8/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.8/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.8/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.8/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.9/multiprocess/tests/mp_preload.py
+++ b/py3.9/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/py3.9/multiprocess/tests/test_multiprocessing_fork.py
+++ b/py3.9/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.9/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/py3.9/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/py3.9/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/py3.9/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.7/multiprocess/tests/mp_preload.py
+++ b/pypy3.7/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocess.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/pypy3.7/multiprocess/tests/test_multiprocessing_fork.py
+++ b/pypy3.7/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.7/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/pypy3.7/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -8,9 +8,9 @@ if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
 if sys.platform == "win32":
-    raise unittest.SkipTest("fork is not available on Windows")
+    raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.7/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/pypy3.7/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.8/multiprocess/tests/mp_preload.py
+++ b/pypy3.8/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/pypy3.8/multiprocess/tests/test_multiprocessing_fork.py
+++ b/pypy3.8/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.8/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/pypy3.8/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.8/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/pypy3.8/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.9/multiprocess/tests/mp_preload.py
+++ b/pypy3.9/multiprocess/tests/mp_preload.py
@@ -9,7 +9,7 @@ def f():
 
 if __name__ == "__main__":
     ctx = multiprocessing.get_context("forkserver")
-    modname = "test.mp_preload"
+    modname = "multiprocess.tests.mp_preload"
     # Make sure it's importable
     __import__(modname)
     ctx.set_forkserver_preload([modname])

--- a/pypy3.9/multiprocess/tests/test_multiprocessing_fork.py
+++ b/pypy3.9/multiprocess/tests/test_multiprocessing_fork.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -13,7 +13,7 @@ if sys.platform == "win32":
 if sys.platform == 'darwin':
     raise unittest.SkipTest("test may crash on macOS (bpo-33725)")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'fork')
+install_tests_in_module_dict(globals(), 'fork')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.9/multiprocess/tests/test_multiprocessing_forkserver.py
+++ b/pypy3.9/multiprocess/tests/test_multiprocessing_forkserver.py
@@ -1,5 +1,5 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 import sys
 from test import support
@@ -10,7 +10,7 @@ if support.PGO:
 if sys.platform == "win32":
     raise unittest.SkipTest("forkserver is not available on Windows")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'forkserver')
+install_tests_in_module_dict(globals(), 'forkserver')
 
 if __name__ == '__main__':
     unittest.main()

--- a/pypy3.9/multiprocess/tests/test_multiprocessing_spawn.py
+++ b/pypy3.9/multiprocess/tests/test_multiprocessing_spawn.py
@@ -1,12 +1,12 @@
 import unittest
-import __init__ as _test_multiprocessing
+from multiprocess.tests import install_tests_in_module_dict
 
 from test import support
 
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-_test_multiprocessing.install_tests_in_module_dict(globals(), 'spawn')
+install_tests_in_module_dict(globals(), 'spawn')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
I have no idea on which Python versions the old code works, but on mine (Python 3.11, Debian) it doesn't.