### PR TITLE
Update LICENSE with the current filename of COPYING

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ Copyright (c) 2016-2023 The Uncertainty Quantification Foundation.
 All rights reserved.
 
 This software forks the python package "multiprocessing". Licence and
-copyright information for multiprocessing can be found in "COPYING.txt".
+copyright information for multiprocessing can be found in "COPYING".
 
 This software is available subject to the conditions and terms laid
 out below. By downloading and using this software you are agreeing


### PR DESCRIPTION
`COPYING.txt` was renamed to `COPYING` in beafd7296a7686e30f631a3864f09650bb79c3ca.