### PR TITLE
Update to use NamedTemporaryFile rather than mktemp

### DIFF
--- a/py3.10/multiprocess/connection.py
+++ b/py3.10/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/py3.11/multiprocess/connection.py
+++ b/py3.11/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/py3.12/multiprocess/connection.py
+++ b/py3.12/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/py3.7/multiprocess/connection.py
+++ b/py3.7/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/py3.8/multiprocess/connection.py
+++ b/py3.8/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/py3.9/multiprocess/connection.py
+++ b/py3.9/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/pypy3.7/multiprocess/connection.py
+++ b/pypy3.7/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/pypy3.8/multiprocess/connection.py
+++ b/pypy3.8/multiprocess/connection.py
@@ -76,10 +76,10 @@ def arbitrary_address(family):
     if family == 'AF_INET':
         return ('localhost', 0)
     elif family == 'AF_UNIX':
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 

--- a/pypy3.9/multiprocess/connection.py
+++ b/pypy3.9/multiprocess/connection.py
@@ -81,10 +81,10 @@ def arbitrary_address(family):
         # sun_path as short as 92 bytes in the sockaddr_un struct.
         if util.abstract_sockets_supported:
             return f"\0listener-{os.getpid()}-{next(_mmap_counter)}"
-        return tempfile.mktemp(prefix='listener-', dir=util.get_temp_dir())
+        return tempfile.NamedTemporaryFile(prefix='listener-', dir=util.get_temp_dir(), delete=False)
     elif family == 'AF_PIPE':
-        return tempfile.mktemp(prefix=r'\\.\pipe\pyc-%d-%d-' %
-                               (os.getpid(), next(_mmap_counter)), dir="")
+        return tempfile.NamedTemporaryFile(prefix=r'\\.\pipe\pyc-%d-%d-' %
+                               (os.getpid(), next(_mmap_counter)), dir="", delete=False)
     else:
         raise ValueError('unrecognized family')
 


### PR DESCRIPTION
## Summary
tempfile.mktemp() has been deprecated (see https://docs.python.org/3/library/tempfile.html#tempfile.mktemp) due to security vulnerability, here I have taken the recommended course of action by replacing with tempfile. NamedTemporaryFile() to resolve the vulnerability. (Our sagemaker-python-sdk package uses multiprocess and was flagged for this vulnerability, please merge and release ASAP!) 
I ran py3.10 tests successfully.

## Checklist

<!-- Please delete any checkboxes that do not apply to this PR. -->

**Documentation and Tests**
- [ ] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
- [ ] Added rationale for any breakage of backwards compatibility.
- [ ] Requested a review.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- Create a new branch for your changes and open the PR from your new branch.

- The PR title should summarize the proposed changes, for example
  "Drop support for python 2.7". Avoid non-descriptive titles such as
  "Addresses issue #8576". Do not include the issue number in the title.

- The summary should provide at least 1-2 sentences describing the PR
  in detail. Why is this change required? What problem does it solve?

- If this PR fixes an issue, please read https://tinyurl.com/auto-closing,
  and follow the formatting suggestions to link relevant issues to this PR.

- If you are contributing fixes to docstrings, please pay attention to
  docstring formatting.  In particular, note the difference between using
  single backquotes, double backquotes, and asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
