### PR TITLE
add build to rtfd config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,8 +7,13 @@ sphinx:
   configuration: docs/source/conf.py
 
 # build
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+# install
 python:
-  version: "3.8"
   install:
     - method: pip
       path: .


### PR DESCRIPTION
## Summary
add build stanza to the readthedocs config file; use python 3.10 for doc build

## Checklist
**Documentation and Tests**
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.