### PR TITLE
sync code with python 3.11.9, 3.12.3, and 3.13.0a6

### DIFF
--- a/py3.11/Modules/_multiprocess/posixshmem.c
+++ b/py3.11/Modules/_multiprocess/posixshmem.c
@@ -42,8 +42,13 @@ _posixshmem_shm_open_impl(PyObject *module, PyObject *path, int flags,
 {
     int fd;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return -1;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return -1;
     }
     do {
@@ -81,8 +86,13 @@ _posixshmem_shm_unlink_impl(PyObject *module, PyObject *path)
 {
     int rv;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return NULL;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return NULL;
     }
     do {

--- a/py3.11/README_MODS
+++ b/py3.11/README_MODS
@@ -1292,4 +1292,78 @@ diff Python-3.11.7/Lib/test/_test_multiprocessing.py Python-3.11.8/Lib/test/_tes
 >             logger.removeHandler(handler)
 >             handler.close()
 > 
-
+# ----------------------------------------------------------------------
+diff Python-3.11.8/Modules/_multiprocessing/posixshmem.c Python-3.11.9/Modules/_multiprocessing/posixshmem.c
+45c45,46
+<     const char *name = PyUnicode_AsUTF8(path);
+---
+>     Py_ssize_t name_size;
+>     const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
+48a50,53
+>     if (strlen(name) != (size_t)name_size) {
+>         PyErr_SetString(PyExc_ValueError, "embedded null character");
+>         return -1;
+>     }
+84c89,90
+<     const char *name = PyUnicode_AsUTF8(path);
+---
+>     Py_ssize_t name_size;
+>     const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
+87a94,97
+>     if (strlen(name) != (size_t)name_size) {
+>         PyErr_SetString(PyExc_ValueError, "embedded null character");
+>         return NULL;
+>     }
+diff Python-3.11.8/Lib/multiprocessing/connection.py Python-3.11.9/Lib/multiprocessing/connection.py
+478a479
+> 
+480c481
+<         if self._authkey:
+---
+>         if self._authkey is not None:
+diff Python-3.11.8/Lib/test/_test_multiprocessing.py Python-3.11.9/Lib/test/_test_multiprocessing.py 
+3467a3468,3491
+>     def test_empty_authkey(self):
+>         # bpo-43952: allow empty bytes as authkey
+>         def handler(*args):
+>             raise RuntimeError('Connection took too long...')
+> 
+>         def run(addr, authkey):
+>             client = self.connection.Client(addr, authkey=authkey)
+>             client.send(1729)
+> 
+>         key = b''
+> 
+>         with self.connection.Listener(authkey=key) as listener:
+>             thread = threading.Thread(target=run, args=(listener.address, key))
+>             thread.start()
+>             try:
+>                 with listener.accept() as d:
+>                     self.assertEqual(d.recv(), 1729)
+>             finally:
+>                 thread.join()
+> 
+>         if self.TYPE == 'processes':
+>             with self.assertRaises(OSError):
+>                 listener.accept()
+> 
+3934a3959,3973
+>     def test_shared_memory_name_with_embedded_null(self):
+>         name_tsmb = self._new_shm_name('test01_null')
+>         sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
+>         self.addCleanup(sms.unlink)
+>         with self.assertRaises(ValueError):
+>             shared_memory.SharedMemory(name_tsmb + '\0a', create=False, size=512)
+>         if shared_memory._USE_POSIX:
+>             orig_name = sms._name
+>             try:
+>                 sms._name = orig_name + '\0a'
+>                 with self.assertRaises(ValueError):
+>                     sms.unlink()
+>             finally:
+>                 sms._name = orig_name
+> 
+4069c4108
+<     def test_invalid_shared_memory_cration(self):
+---
+>     def test_invalid_shared_memory_creation(self):

--- a/py3.11/multiprocess/connection.py
+++ b/py3.11/multiprocess/connection.py
@@ -479,8 +479,9 @@ class Listener(object):
         '''
         if self._listener is None:
             raise OSError('listener is closed')
+
         c = self._listener.accept()
-        if self._authkey:
+        if self._authkey is not None:
             deliver_challenge(c, self._authkey)
             answer_challenge(c, self._authkey)
         return c

--- a/py3.11/multiprocess/tests/__init__.py
+++ b/py3.11/multiprocess/tests/__init__.py
@@ -3476,6 +3476,30 @@ class _TestListener(BaseTestCase):
         if self.TYPE == 'processes':
             self.assertRaises(OSError, l.accept)
 
+    def test_empty_authkey(self):
+        # bpo-43952: allow empty bytes as authkey
+        def handler(*args):
+            raise RuntimeError('Connection took too long...')
+
+        def run(addr, authkey):
+            client = self.connection.Client(addr, authkey=authkey)
+            client.send(1729)
+
+        key = b''
+
+        with self.connection.Listener(authkey=key) as listener:
+            thread = threading.Thread(target=run, args=(listener.address, key))
+            thread.start()
+            try:
+                with listener.accept() as d:
+                    self.assertEqual(d.recv(), 1729)
+            finally:
+                thread.join()
+
+        if self.TYPE == 'processes':
+            with self.assertRaises(OSError):
+                listener.accept()
+
     @unittest.skipUnless(util.abstract_sockets_supported,
                          "test needs abstract socket support")
     def test_abstract_socket(self):
@@ -3943,6 +3967,22 @@ class _TestSharedMemory(BaseTestCase):
         # test_multiprocessing_spawn, etc) in parallel.
         return prefix + str(os.getpid())
 
+    @unittest.skipIf(sys.hexversion <= 0x30b08f0, "added in 3.11.9")
+    def test_shared_memory_name_with_embedded_null(self):
+        name_tsmb = self._new_shm_name('test01_null')
+        sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
+        self.addCleanup(sms.unlink)
+        with self.assertRaises(ValueError):
+            shared_memory.SharedMemory(name_tsmb + '\0a', create=False, size=512)
+        if shared_memory._USE_POSIX:
+            orig_name = sms._name
+            try:
+                sms._name = orig_name + '\0a'
+                with self.assertRaises(ValueError):
+                    sms.unlink()
+            finally:
+                sms._name = orig_name
+
     def test_shared_memory_basics(self):
         name_tsmb = self._new_shm_name('test01_tsmb')
         sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
@@ -4078,7 +4118,7 @@ class _TestSharedMemory(BaseTestCase):
             self.addCleanup(shm2.unlink)
             self.assertEqual(shm2._name, names[1])
 
-    def test_invalid_shared_memory_cration(self):
+    def test_invalid_shared_memory_creation(self):
         # Test creating a shared memory segment with negative size
         with self.assertRaises(ValueError):
             sms_invalid = shared_memory.SharedMemory(create=True, size=-1)

--- a/py3.12/Modules/_multiprocess/posixshmem.c
+++ b/py3.12/Modules/_multiprocess/posixshmem.c
@@ -42,8 +42,13 @@ _posixshmem_shm_open_impl(PyObject *module, PyObject *path, int flags,
 {
     int fd;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return -1;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return -1;
     }
     do {
@@ -81,8 +86,13 @@ _posixshmem_shm_unlink_impl(PyObject *module, PyObject *path)
 {
     int rv;
     int async_err = 0;
-    const char *name = PyUnicode_AsUTF8(path);
+    Py_ssize_t name_size;
+    const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
     if (name == NULL) {
+        return NULL;
+    }
+    if (strlen(name) != (size_t)name_size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return NULL;
     }
     do {

--- a/py3.12/README_MODS
+++ b/py3.12/README_MODS
@@ -1500,3 +1500,78 @@ diff Python-3.12.1/Lib/test/_test_multiprocessing.py Python-3.12.2/Lib/test/_tes
 >             logger.removeHandler(handler)
 >             handler.close()
 > 
+# ----------------------------------------------------------------------
+diff Python-3.12.2/Modules/_multiprocessing/posixshmem.c Python-3.12.3/Modules/_multiprocessing/posixshmem.c
+45c45,46
+<     const char *name = PyUnicode_AsUTF8(path);
+---
+>     Py_ssize_t name_size;
+>     const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
+48a50,53
+>     if (strlen(name) != (size_t)name_size) {
+>         PyErr_SetString(PyExc_ValueError, "embedded null character");
+>         return -1;
+>     }
+84c89,90
+<     const char *name = PyUnicode_AsUTF8(path);
+---
+>     Py_ssize_t name_size;
+>     const char *name = PyUnicode_AsUTF8AndSize(path, &name_size);
+87a94,97
+>     if (strlen(name) != (size_t)name_size) {
+>         PyErr_SetString(PyExc_ValueError, "embedded null character");
+>         return NULL;
+>     }
+diff Python-3.12.2/Lib/multiprocessing/connection.py Python-3.12.3/Lib/multiprocessing/connection.py
+478a479
+> 
+480c481
+<         if self._authkey:
+---
+>         if self._authkey is not None:
+diff Python-3.12.2/Lib/test/_test_multiprocessing.py Python-3.12.3/Lib/test/_test_multiprocessing.py 
+3468a3469,3492
+>     def test_empty_authkey(self):
+>         # bpo-43952: allow empty bytes as authkey
+>         def handler(*args):
+>             raise RuntimeError('Connection took too long...')
+> 
+>         def run(addr, authkey):
+>             client = self.connection.Client(addr, authkey=authkey)
+>             client.send(1729)
+> 
+>         key = b''
+> 
+>         with self.connection.Listener(authkey=key) as listener:
+>             thread = threading.Thread(target=run, args=(listener.address, key))
+>             thread.start()
+>             try:
+>                 with listener.accept() as d:
+>                     self.assertEqual(d.recv(), 1729)
+>             finally:
+>                 thread.join()
+> 
+>         if self.TYPE == 'processes':
+>             with self.assertRaises(OSError):
+>                 listener.accept()
+> 
+3935a3960,3974
+>     def test_shared_memory_name_with_embedded_null(self):
+>         name_tsmb = self._new_shm_name('test01_null')
+>         sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
+>         self.addCleanup(sms.unlink)
+>         with self.assertRaises(ValueError):
+>             shared_memory.SharedMemory(name_tsmb + '\0a', create=False, size=512)
+>         if shared_memory._USE_POSIX:
+>             orig_name = sms._name
+>             try:
+>                 sms._name = orig_name + '\0a'
+>                 with self.assertRaises(ValueError):
+>                     sms.unlink()
+>             finally:
+>                 sms._name = orig_name
+> 
+4070c4109
+<     def test_invalid_shared_memory_cration(self):
+---
+>     def test_invalid_shared_memory_creation(self):

--- a/py3.12/multiprocess/connection.py
+++ b/py3.12/multiprocess/connection.py
@@ -479,8 +479,9 @@ class Listener(object):
         '''
         if self._listener is None:
             raise OSError('listener is closed')
+
         c = self._listener.accept()
-        if self._authkey:
+        if self._authkey is not None:
             deliver_challenge(c, self._authkey)
             answer_challenge(c, self._authkey)
         return c

--- a/py3.12/multiprocess/tests/__init__.py
+++ b/py3.12/multiprocess/tests/__init__.py
@@ -3476,6 +3476,30 @@ class _TestListener(BaseTestCase):
         if self.TYPE == 'processes':
             self.assertRaises(OSError, l.accept)
 
+    def test_empty_authkey(self):
+        # bpo-43952: allow empty bytes as authkey
+        def handler(*args):
+            raise RuntimeError('Connection took too long...')
+
+        def run(addr, authkey):
+            client = self.connection.Client(addr, authkey=authkey)
+            client.send(1729)
+
+        key = b''
+
+        with self.connection.Listener(authkey=key) as listener:
+            thread = threading.Thread(target=run, args=(listener.address, key))
+            thread.start()
+            try:
+                with listener.accept() as d:
+                    self.assertEqual(d.recv(), 1729)
+            finally:
+                thread.join()
+
+        if self.TYPE == 'processes':
+            with self.assertRaises(OSError):
+                listener.accept()
+
     @unittest.skipUnless(util.abstract_sockets_supported,
                          "test needs abstract socket support")
     def test_abstract_socket(self):
@@ -3943,6 +3967,22 @@ class _TestSharedMemory(BaseTestCase):
         # test_multiprocessing_spawn, etc) in parallel.
         return prefix + str(os.getpid())
 
+    @unittest.skipIf(sys.hexversion <= 0x30c02f0, "added in 3.12.3")
+    def test_shared_memory_name_with_embedded_null(self):
+        name_tsmb = self._new_shm_name('test01_null')
+        sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
+        self.addCleanup(sms.unlink)
+        with self.assertRaises(ValueError):
+            shared_memory.SharedMemory(name_tsmb + '\0a', create=False, size=512)           
+        if shared_memory._USE_POSIX:
+            orig_name = sms._name
+            try:
+                sms._name = orig_name + '\0a'
+                with self.assertRaises(ValueError):
+                    sms.unlink()
+            finally:
+                sms._name = orig_name
+
     def test_shared_memory_basics(self):
         name_tsmb = self._new_shm_name('test01_tsmb')
         sms = shared_memory.SharedMemory(name_tsmb, create=True, size=512)
@@ -4078,7 +4118,7 @@ class _TestSharedMemory(BaseTestCase):
             self.addCleanup(shm2.unlink)
             self.assertEqual(shm2._name, names[1])
 
-    def test_invalid_shared_memory_cration(self):
+    def test_invalid_shared_memory_creation(self):
         # Test creating a shared memory segment with negative size
         with self.assertRaises(ValueError):
             sms_invalid = shared_memory.SharedMemory(create=True, size=-1)

--- a/py3.13/Modules/_multiprocess/semaphore.c
+++ b/py3.13/Modules/_multiprocess/semaphore.c
@@ -81,6 +81,7 @@ _GetSemaphoreValue(HANDLE handle, long *value)
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.acquire
 
     block as blocking: bool = True
@@ -92,7 +93,7 @@ Acquire the semaphore/lock.
 static PyObject *
 _multiprocess_SemLock_acquire_impl(SemLockObject *self, int blocking,
                                       PyObject *timeout_obj)
-/*[clinic end generated code: output=f9998f0b6b0b0872 input=e5b45f5cbb775166]*/
+/*[clinic end generated code: output=f9998f0b6b0b0872 input=079ca779975f3ad6]*/
 {
     double timeout;
     DWORD res, full_msecs, nhandles;
@@ -172,6 +173,7 @@ _multiprocess_SemLock_acquire_impl(SemLockObject *self, int blocking,
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.release
 
 Release the semaphore/lock.
@@ -179,7 +181,7 @@ Release the semaphore/lock.
 
 static PyObject *
 _multiprocess_SemLock_release_impl(SemLockObject *self)
-/*[clinic end generated code: output=b22f53ba96b0d1db input=ba7e63a961885d3d]*/
+/*[clinic end generated code: output=b22f53ba96b0d1db input=9bd62d3645e7a531]*/
 {
     if (self->kind == RECURSIVE_MUTEX) {
         if (!ISMINE(self)) {
@@ -297,6 +299,7 @@ sem_timedwait_save(sem_t *sem, struct timespec *deadline, PyThreadState *_save)
 #endif /* !HAVE_SEM_TIMEDWAIT */
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.acquire
 
     block as blocking: bool = True
@@ -308,7 +311,7 @@ Acquire the semaphore/lock.
 static PyObject *
 _multiprocess_SemLock_acquire_impl(SemLockObject *self, int blocking,
                                       PyObject *timeout_obj)
-/*[clinic end generated code: output=f9998f0b6b0b0872 input=e5b45f5cbb775166]*/
+/*[clinic end generated code: output=f9998f0b6b0b0872 input=079ca779975f3ad6]*/
 {
     int res, err = 0;
     struct timespec deadline = {0};
@@ -382,6 +385,7 @@ _multiprocess_SemLock_acquire_impl(SemLockObject *self, int blocking,
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.release
 
 Release the semaphore/lock.
@@ -389,7 +393,7 @@ Release the semaphore/lock.
 
 static PyObject *
 _multiprocess_SemLock_release_impl(SemLockObject *self)
-/*[clinic end generated code: output=b22f53ba96b0d1db input=ba7e63a961885d3d]*/
+/*[clinic end generated code: output=b22f53ba96b0d1db input=9bd62d3645e7a531]*/
 {
     if (self->kind == RECURSIVE_MUTEX) {
         if (!ISMINE(self)) {
@@ -583,6 +587,7 @@ semlock_dealloc(SemLockObject* self)
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock._count
 
 Num of `acquire()`s minus num of `release()`s for this process.
@@ -590,7 +595,7 @@ Num of `acquire()`s minus num of `release()`s for this process.
 
 static PyObject *
 _multiprocess_SemLock__count_impl(SemLockObject *self)
-/*[clinic end generated code: output=5ba8213900e517bb input=36fc59b1cd1025ab]*/
+/*[clinic end generated code: output=5ba8213900e517bb input=9fa6e0b321b16935]*/
 {
     return PyLong_FromLong((long)self->count);
 }

--- a/py3.13/README_MODS
+++ b/py3.13/README_MODS
@@ -1237,3 +1237,40 @@ diff Python-3.13.0a4/Lib/test/_test_multiprocessing.py Python-3.13.0a5/Lib/test/
 >                 self._test_resource_tracker_leak_resources(
 >                     cleanup=cleanup,
 >                 )
+# ----------------------------------------------------------------------
+diff Python-3.13.0a5/Modules/_multiprocessing/semaphore.c Python-3.13.0a6/Modules/_multiprocessing/semaphore.c
+83a84
+> @critical_section
+95c96
+< /*[clinic end generated code: output=f9998f0b6b0b0872 input=e5b45f5cbb775166]*/
+---
+> /*[clinic end generated code: output=f9998f0b6b0b0872 input=079ca779975f3ad6]*/
+174a176
+> @critical_section
+182c184
+< /*[clinic end generated code: output=b22f53ba96b0d1db input=ba7e63a961885d3d]*/
+---
+> /*[clinic end generated code: output=b22f53ba96b0d1db input=9bd62d3645e7a531]*/
+299a302
+> @critical_section
+311c314
+< /*[clinic end generated code: output=f9998f0b6b0b0872 input=e5b45f5cbb775166]*/
+---
+> /*[clinic end generated code: output=f9998f0b6b0b0872 input=079ca779975f3ad6]*/
+384a388
+> @critical_section
+392c396
+< /*[clinic end generated code: output=b22f53ba96b0d1db input=ba7e63a961885d3d]*/
+---
+> /*[clinic end generated code: output=b22f53ba96b0d1db input=9bd62d3645e7a531]*/
+585a590
+> @critical_section
+593c598
+< /*[clinic end generated code: output=5ba8213900e517bb input=36fc59b1cd1025ab]*/
+---
+> /*[clinic end generated code: output=5ba8213900e517bb input=9fa6e0b321b16935]*/
+diff Python-3.13.0a5/Lib/test/_test_multiprocessing.py Python-3.13.0a6/Lib/test/_test_multiprocessing.py 
+4665c4665
+<             sys.setswitchinterval(1e-6)
+---
+>             support.setswitchinterval(1e-6)

--- a/py3.13/multiprocess/tests/__init__.py
+++ b/py3.13/multiprocess/tests/__init__.py
@@ -4674,7 +4674,7 @@ class _TestFinalize(BaseTestCase):
         old_interval = sys.getswitchinterval()
         old_threshold = gc.get_threshold()
         try:
-            sys.setswitchinterval(1e-6)
+            support.setswitchinterval(1e-6)
             gc.set_threshold(5, 5, 5)
             threads = [threading.Thread(target=run_finalizers),
                        threading.Thread(target=make_finalizers)]


### PR DESCRIPTION
## Summary
sync code with python 3.11.9, 3.12.3, and 3.13.0a6

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Added relevant documentation that builds in sphinx without error.
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [ ] Added rationale for any breakage of backwards compatibility.