### PR TITLE
sync code with python 3.12.5, 3.13.0rc1, and pypy 7.3.17

### DIFF
--- a/py3.12/README_MODS
+++ b/py3.12/README_MODS
@@ -1119,7 +1119,7 @@ diff Python-3.12.0b4/Lib/test/_test_multiprocessing.py Python-3.12.0rc2/Lib/test
 >                 continue
 > 
 # ----------------------------------------------------------------------
-$ diff Python-3.12.0rc2/Lib/test/_test_multiprocessing.py  Python-3.12.0rc3/Lib/test/_test_multiprocessing.py 
+diff Python-3.12.0rc2/Lib/test/_test_multiprocessing.py  Python-3.12.0rc3/Lib/test/_test_multiprocessing.py 
 677a678
 >     @support.requires_resource('walltime')
 4955a4957
@@ -1575,3 +1575,42 @@ diff Python-3.12.2/Lib/test/_test_multiprocessing.py Python-3.12.3/Lib/test/_tes
 <     def test_invalid_shared_memory_cration(self):
 ---
 >     def test_invalid_shared_memory_creation(self):
+# ----------------------------------------------------------------------
+diff Python-3.12.3/Lib/test/_test_multiprocessing.py Python-3.12.5/Lib/test/_test_multiprocessing.py 
+25d24
+< import pathlib
+327,328c326,328
+<             sys.executable.encode(),      # bytes
+<             pathlib.Path(sys.executable)  # os.PathLike
+---
+>             os.fsencode(sys.executable),  # bytes
+>             os_helper.FakePath(sys.executable),  # os.PathLike
+>             os_helper.FakePath(os.fsencode(sys.executable)),  # os.PathLike bytes
+1334a1335,1351
+>     def test_closed_queue_empty_exceptions(self):
+>         # Assert that checking the emptiness of an unused closed queue
+>         # does not raise an OSError. The rationale is that q.close() is
+>         # a no-op upon construction and becomes effective once the queue
+>         # has been used (e.g., by calling q.put()).
+>         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
+>             q.close()  # this is a no-op since the feeder thread is None
+>             q.join_thread()  # this is also a no-op
+>             self.assertTrue(q.empty())
+> 
+>         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
+>             q.put('foo')  # make sure that the queue is 'used'
+>             q.close()  # close the feeder thread
+>             q.join_thread()  # make sure to join the feeder thread
+>             with self.assertRaisesRegex(OSError, 'is closed'):
+>                 q.empty()
+> 
+5693a5711,5719
+>     def test_empty_exceptions(self):
+>         # Assert that checking emptiness of a closed queue raises
+>         # an OSError, independently of whether the queue was used
+>         # or not. This differs from Queue and JoinableQueue.
+>         q = multiprocessing.SimpleQueue()
+>         q.close()  # close the pipe
+>         with self.assertRaisesRegex(OSError, 'is closed'):
+>             q.empty()
+> 

--- a/py3.13/Modules/_multiprocess/clinic/semaphore.c.h
+++ b/py3.13/Modules/_multiprocess/clinic/semaphore.c.h
@@ -6,6 +6,7 @@ preserve
 #  include "pycore_gc.h"          // PyGC_Head
 #  include "pycore_runtime.h"     // _Py_ID()
 #endif
+#include "pycore_critical_section.h"// Py_BEGIN_CRITICAL_SECTION()
 #include "pycore_modsupport.h"    // _PyArg_UnpackKeywords()
 
 #if defined(HAVE_MP_SEMAPHORE) && defined(MS_WINDOWS)
@@ -75,7 +76,9 @@ _multiprocessing_SemLock_acquire(SemLockObject *self, PyObject *const *args, Py_
     }
     timeout_obj = args[1];
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _multiprocessing_SemLock_acquire_impl(self, blocking, timeout_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -100,7 +103,13 @@ _multiprocessing_SemLock_release_impl(SemLockObject *self);
 static PyObject *
 _multiprocessing_SemLock_release(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _multiprocessing_SemLock_release_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _multiprocessing_SemLock_release_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_MP_SEMAPHORE) && defined(MS_WINDOWS) */
@@ -172,7 +181,9 @@ _multiprocessing_SemLock_acquire(SemLockObject *self, PyObject *const *args, Py_
     }
     timeout_obj = args[1];
 skip_optional_pos:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _multiprocessing_SemLock_acquire_impl(self, blocking, timeout_obj);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -197,7 +208,13 @@ _multiprocessing_SemLock_release_impl(SemLockObject *self);
 static PyObject *
 _multiprocessing_SemLock_release(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _multiprocessing_SemLock_release_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _multiprocessing_SemLock_release_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_MP_SEMAPHORE) && !defined(MS_WINDOWS) */
@@ -340,7 +357,13 @@ _multiprocessing_SemLock__count_impl(SemLockObject *self);
 static PyObject *
 _multiprocessing_SemLock__count(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _multiprocessing_SemLock__count_impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _multiprocessing_SemLock__count_impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_MP_SEMAPHORE) */
@@ -450,7 +473,13 @@ _multiprocessing_SemLock___enter___impl(SemLockObject *self);
 static PyObject *
 _multiprocessing_SemLock___enter__(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
-    return _multiprocessing_SemLock___enter___impl(self);
+    PyObject *return_value = NULL;
+
+    Py_BEGIN_CRITICAL_SECTION(self);
+    return_value = _multiprocessing_SemLock___enter___impl(self);
+    Py_END_CRITICAL_SECTION();
+
+    return return_value;
 }
 
 #endif /* defined(HAVE_MP_SEMAPHORE) */
@@ -495,7 +524,9 @@ _multiprocessing_SemLock___exit__(SemLockObject *self, PyObject *const *args, Py
     }
     exc_tb = args[2];
 skip_optional:
+    Py_BEGIN_CRITICAL_SECTION(self);
     return_value = _multiprocessing_SemLock___exit___impl(self, exc_type, exc_value, exc_tb);
+    Py_END_CRITICAL_SECTION();
 
 exit:
     return return_value;
@@ -542,4 +573,4 @@ exit:
 #ifndef _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
     #define _MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF
 #endif /* !defined(_MULTIPROCESSING_SEMLOCK___EXIT___METHODDEF) */
-/*[clinic end generated code: output=d57992037e6770b6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dea36482d23a355f input=a9049054013a1b77]*/

--- a/py3.13/Modules/_multiprocess/multiprocess.c
+++ b/py3.13/Modules/_multiprocess/multiprocess.c
@@ -277,6 +277,7 @@ multiprocess_exec(PyObject *module)
 static PyModuleDef_Slot multiprocess_slots[] = {
     {Py_mod_exec, multiprocess_exec},
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}
 };
 

--- a/py3.13/Modules/_multiprocess/posixshmem.c
+++ b/py3.13/Modules/_multiprocess/posixshmem.c
@@ -2,10 +2,10 @@
 posixshmem - A Python extension that provides shm_open() and shm_unlink()
 */
 
-// Need limited C API version 3.12 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+// Need limited C API version 3.13 for Py_mod_gil
 #include "pyconfig.h"   // Py_GIL_DISABLED
 #ifndef Py_GIL_DISABLED
-#  define Py_LIMITED_API 0x030c0000
+#  define Py_LIMITED_API 0x030d0000
 #endif
 
 #include <Python.h>
@@ -128,6 +128,7 @@ static PyMethodDef module_methods[ ] = {
 
 static PyModuleDef_Slot module_slots[] = {
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
     {0, NULL}
 };
 

--- a/py3.13/Modules/_multiprocess/semaphore.c
+++ b/py3.13/Modules/_multiprocess/semaphore.c
@@ -682,6 +682,7 @@ _multiprocess_SemLock__after_fork_impl(SemLockObject *self)
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.__enter__
 
 Enter the semaphore/lock.
@@ -689,12 +690,13 @@ Enter the semaphore/lock.
 
 static PyObject *
 _multiprocess_SemLock___enter___impl(SemLockObject *self)
-/*[clinic end generated code: output=beeb2f07c858511f input=c5e27d594284690b]*/
+/*[clinic end generated code: output=beeb2f07c858511f input=d35c9860992ee790]*/
 {
     return _multiprocess_SemLock_acquire_impl(self, 1, Py_None);
 }
 
 /*[clinic input]
+@critical_section
 _multiprocess.SemLock.__exit__
 
     exc_type: object = None
@@ -709,7 +711,7 @@ static PyObject *
 _multiprocess_SemLock___exit___impl(SemLockObject *self,
                                        PyObject *exc_type,
                                        PyObject *exc_value, PyObject *exc_tb)
-/*[clinic end generated code: output=3b37c1a9f8b91a03 input=7d644b64a89903f8]*/
+/*[clinic end generated code: output=3b37c1a9f8b91a03 input=1610c8cc3e0e337e]*/
 {
     return _multiprocess_SemLock_release_impl(self);
 }

--- a/py3.13/README_MODS
+++ b/py3.13/README_MODS
@@ -1274,3 +1274,156 @@ diff Python-3.13.0a5/Lib/test/_test_multiprocessing.py Python-3.13.0a6/Lib/test/
 <             sys.setswitchinterval(1e-6)
 ---
 >             support.setswitchinterval(1e-6)
+# ----------------------------------------------------------------------
+diff Python-3.13.0a6/Modules/_multiprocessing/multiprocessing.c Python-3.13.0b1/Modules/_multiprocessing/multiprocessing.c
+279a280
+>     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+diff Python-3.13.0a6/Modules/_multiprocessing/posixshmem.c Python-3.13.0b1/Modules/_multiprocessing/posixshmem.c
+5c5
+< // Need limited C API version 3.12 for Py_MOD_PER_INTERPRETER_GIL_SUPPORTED
+---
+> // Need limited C API version 3.13 for Py_mod_gil
+8c8
+< #  define Py_LIMITED_API 0x030c0000
+---
+> #  define Py_LIMITED_API 0x030d0000
+130a131
+>     {Py_mod_gil, Py_MOD_GIL_NOT_USED},
+diff Python-3.13.0a6/Lib/multiprocessing/forkserver.py Python-3.13.0b1/Lib/multiprocessing/forkserver.py
+0a1
+> import atexit
+273a275,276
+>                                 atexit._clear()
+>                                 atexit.register(util._exit_function)
+280a284
+>                                 atexit._run_exitfuncs()
+diff Python-3.13.0a6/Lib/multiprocessing/popen_fork.py Python-3.13.0b1/Lib/multiprocessing/popen_fork.py
+0a1
+> import atexit
+68a70,71
+>                 atexit._clear()
+>                 atexit.register(util._exit_function)
+72a76
+>                 atexit._run_exitfuncs()
+diff Python-3.13.0a6/Lib/multiprocessing/popen_spawn_win32.py Python-3.13.0b1/Lib/multiprocessing/popen_spawn_win32.py
+5a6
+> from subprocess import STARTUPINFO, STARTF_FORCEOFFFEEDBACK
+77c78,79
+<                     None, None, False, 0, env, None, None)
+---
+>                     None, None, False, 0, env, None,
+>                     STARTUPINFO(dwFlags=STARTF_FORCEOFFFEEDBACK))
+diff Python-3.13.0a6/Lib/multiprocessing/process.py Python-3.13.0b1/Lib/multiprocessing/process.py
+313,317c313,314
+<             try:
+<                 self.run()
+<                 exitcode = 0
+<             finally:
+<                 util._exit_function()
+---
+>             self.run()
+>             exitcode = 0
+diff Python-3.13.0a6/Lib/test/_test_multiprocessing.py Python-3.13.0b1/Lib/test/_test_multiprocessing.py 
+2815d2814
+<         gc.collect()  # For PyPy or other GCs.
+2816a2816
+>         support.gc_collect()  # For PyPy or other GCs.
+6163a6164,6186
+> class _TestAtExit(BaseTestCase):
+> 
+>     ALLOWED_TYPES = ('processes',)
+> 
+>     @classmethod
+>     def _write_file_at_exit(self, output_path):
+>         import atexit
+>         def exit_handler():
+>             with open(output_path, 'w') as f:
+>                 f.write("deadbeef")
+>         atexit.register(exit_handler)
+> 
+>     def test_atexit(self):
+>         # gh-83856
+>         with os_helper.temp_dir() as temp_dir:
+>             output_path = os.path.join(temp_dir, 'output.txt')
+>             p = self.Process(target=self._write_file_at_exit, args=(output_path,))
+>             p.start()
+>             p.join()
+>             with open(output_path) as f:
+>                 self.assertEqual(f.read(), 'deadbeef')
+> 
+> 
+# ----------------------------------------------------------------------
+diff Python-3.13.0b1/Modules/_multiprocessing Python-3.13.0rc1/Modules/_multiprocessing/
+diff Python-3.13.0b1/Modules/_multiprocessing/semaphore.c Python-3.13.0rc1/Modules/_multiprocessing/semaphore.c
+684a685
+> @critical_section
+692c693
+< /*[clinic end generated code: output=beeb2f07c858511f input=c5e27d594284690b]*/
+---
+> /*[clinic end generated code: output=beeb2f07c858511f input=d35c9860992ee790]*/
+697a699
+> @critical_section
+712c714
+< /*[clinic end generated code: output=3b37c1a9f8b91a03 input=7d644b64a89903f8]*/
+---
+> /*[clinic end generated code: output=3b37c1a9f8b91a03 input=1610c8cc3e0e337e]*/
+# ----------------------------------------------------------------------
+diff Python-3.13.0b1/Modules/_multiprocessing/clinic/ Python-3.13.0rc1/Modules/_multiprocessing/clinic/
+diff Python-3.13.0b1/Modules/_multiprocessing/clinic/semaphore.c.h Python-3.13.0rc1/Modules/_multiprocessing/clinic/semaphore.c.h
+476c476,482
+<     return _multiprocessing_SemLock___enter___impl(self);
+---
+>     PyObject *return_value = NULL;
+> 
+>     Py_BEGIN_CRITICAL_SECTION(self);
+>     return_value = _multiprocessing_SemLock___enter___impl(self);
+>     Py_END_CRITICAL_SECTION();
+> 
+>     return return_value;
+520a527
+>     Py_BEGIN_CRITICAL_SECTION(self);
+521a529
+>     Py_END_CRITICAL_SECTION();
+568c576
+< /*[clinic end generated code: output=713b597256233716 input=a9049054013a1b77]*/
+---
+> /*[clinic end generated code: output=dea36482d23a355f input=a9049054013a1b77]*/
+# ----------------------------------------------------------------------
+diff Python-3.13.0b1/Lib/test/_test_multiprocessing.py Python-3.13.0rc1/Lib/test/_test_multiprocessing.py 
+25d24
+< import pathlib
+327,328c326,328
+<             sys.executable.encode(),      # bytes
+<             pathlib.Path(sys.executable)  # os.PathLike
+---
+>             os.fsencode(sys.executable),  # bytes
+>             os_helper.FakePath(sys.executable),  # os.PathLike
+>             os_helper.FakePath(os.fsencode(sys.executable)),  # os.PathLike bytes
+1334a1335,1351
+>     def test_closed_queue_empty_exceptions(self):
+>         # Assert that checking the emptiness of an unused closed queue
+>         # does not raise an OSError. The rationale is that q.close() is
+>         # a no-op upon construction and becomes effective once the queue
+>         # has been used (e.g., by calling q.put()).
+>         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
+>             q.close()  # this is a no-op since the feeder thread is None
+>             q.join_thread()  # this is also a no-op
+>             self.assertTrue(q.empty())
+> 
+>         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
+>             q.put('foo')  # make sure that the queue is 'used'
+>             q.close()  # close the feeder thread
+>             q.join_thread()  # make sure to join the feeder thread
+>             with self.assertRaisesRegex(OSError, 'is closed'):
+>                 q.empty()
+> 
+5817a5835,5843
+>     def test_empty_exceptions(self):
+>         # Assert that checking emptiness of a closed queue raises
+>         # an OSError, independently of whether the queue was used
+>         # or not. This differs from Queue and JoinableQueue.
+>         q = multiprocessing.SimpleQueue()
+>         q.close()  # close the pipe
+>         with self.assertRaisesRegex(OSError, 'is closed'):
+>             q.empty()
+> 

--- a/py3.13/multiprocess/forkserver.py
+++ b/py3.13/multiprocess/forkserver.py
@@ -1,3 +1,4 @@
+import atexit
 import errno
 import os
 import selectors
@@ -270,6 +271,8 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                                 selector.close()
                                 unused_fds = [alive_r, child_w, sig_r, sig_w]
                                 unused_fds.extend(pid_to_fd.values())
+                                atexit._clear()
+                                atexit.register(util._exit_function)
                                 code = _serve_one(child_r, fds,
                                                   unused_fds,
                                                   old_handlers)
@@ -277,6 +280,7 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                                 sys.excepthook(*sys.exc_info())
                                 sys.stderr.flush()
                             finally:
+                                atexit._run_exitfuncs()
                                 os._exit(code)
                         else:
                             # Send pid to client process

--- a/py3.13/multiprocess/popen_fork.py
+++ b/py3.13/multiprocess/popen_fork.py
@@ -1,3 +1,4 @@
+import atexit
 import os
 import signal
 
@@ -66,10 +67,13 @@ class Popen(object):
         self.pid = os.fork()
         if self.pid == 0:
             try:
+                atexit._clear()
+                atexit.register(util._exit_function)
                 os.close(parent_r)
                 os.close(parent_w)
                 code = process_obj._bootstrap(parent_sentinel=child_r)
             finally:
+                atexit._run_exitfuncs()
                 os._exit(code)
         else:
             os.close(child_w)

--- a/py3.13/multiprocess/popen_spawn_win32.py
+++ b/py3.13/multiprocess/popen_spawn_win32.py
@@ -3,6 +3,7 @@ import msvcrt
 import signal
 import sys
 import _winapi
+from subprocess import STARTUPINFO, STARTF_FORCEOFFFEEDBACK
 
 from .context import reduction, get_spawning_popen, set_spawning_popen
 from . import spawn
@@ -74,7 +75,8 @@ class Popen(object):
             try:
                 hp, ht, pid, tid = _winapi.CreateProcess(
                     python_exe, cmd,
-                    None, None, False, 0, env, None, None)
+                    None, None, False, 0, env, None,
+                    STARTUPINFO(dwFlags=STARTF_FORCEOFFFEEDBACK))
                 _winapi.CloseHandle(ht)
             except:
                 _winapi.CloseHandle(rhandle)

--- a/py3.13/multiprocess/process.py
+++ b/py3.13/multiprocess/process.py
@@ -310,11 +310,8 @@ class BaseProcess(object):
                 # _run_after_forkers() is executed
                 del old_process
             util.info('child process calling self.run()')
-            try:
-                self.run()
-                exitcode = 0
-            finally:
-                util._exit_function()
+            self.run()
+            exitcode = 0
         except SystemExit as e:
             if e.code is None:
                 exitcode = 0

--- a/pypy3.10/README_MODS
+++ b/pypy3.10/README_MODS
@@ -37,3 +37,23 @@ $ diff Python-3.10.9/Lib/test/_test_multiprocessing.py pypy3.10-v7.3.12-src/lib-
 >             gc.collect()
 4356a4367
 >     @test.support.cpython_only
+# ----------------------------------------------------------------------
+diff pypy3.10-v7.3.15-src/lib-python/3/multiprocessing/managers.py pypy3.10-v7.3.16-src/lib-python/3/multiprocessing/managers.py
+729a730
+>                 conn.close()
+diff pypy3.10-v7.3.15-src/lib-python/3/multiprocessing/popen_spawn_win32.py pypy3.10-v7.3.16-src/lib-python/3/multiprocessing/popen_spawn_win32.py
+25c25,27
+< WINENV = not _path_eq(sys.executable, sys._base_executable)
+---
+> # PyPy is not affected by bpo-35797
+> # WINENV = not _path_eq(sys.executable, sys._base_executable)
+> WINENV = False
+# ----------------------------------------------------------------------
+diff pypy3.10-v7.3.16-src/lib-python/3/multiprocessing/context.py pypy3.10-v7.3.17-src/lib-python/3/multiprocessing/context.py
+229a230
+> 
+diff pypy3.10-v7.3.16-src/lib-python/3/test/_test_multiprocessing.py pypy3.10-v7.3.17-src/lib-python/3/test/_test_multiprocessing.py 
+5738d5737
+< 
+5740d5738
+< 

--- a/pypy3.10/multiprocess/context.py
+++ b/pypy3.10/multiprocess/context.py
@@ -227,6 +227,7 @@ class Process(process.BaseProcess):
     def _after_fork():
         return _default_context.get_context().Process._after_fork()
 
+
 class DefaultContext(BaseContext):
     Process = Process
 

--- a/pypy3.10/multiprocess/managers.py
+++ b/pypy3.10/multiprocess/managers.py
@@ -727,6 +727,7 @@ class BaseManager(object):
                     )
                 conn = self._Client(token.address, authkey=self._authkey)
                 dispatch(conn, None, 'decref', (token.id,))
+                conn.close()
                 return proxy
             temp.__name__ = typeid
             setattr(cls, typeid, temp)

--- a/pypy3.10/multiprocess/popen_spawn_win32.py
+++ b/pypy3.10/multiprocess/popen_spawn_win32.py
@@ -22,7 +22,9 @@ WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 def _path_eq(p1, p2):
     return p1 == p2 or os.path.normcase(p1) == os.path.normcase(p2)
 
-WINENV = not _path_eq(sys.executable, sys._base_executable)
+# PyPy is not affected by bpo-35797
+# WINENV = not _path_eq(sys.executable, sys._base_executable)
+WINENV = False
 
 
 def _close_handles(*handles):

--- a/pypy3.10/multiprocess/tests/__init__.py
+++ b/pypy3.10/multiprocess/tests/__init__.py
@@ -5750,9 +5750,7 @@ class TestNamedResource(unittest.TestCase):
         with open(testfn, 'w', encoding='utf-8') as f:
             f.write(textwrap.dedent('''\
                 import multiprocess as mp
-
                 ctx = mp.get_context('spawn')
-
                 global_resource = ctx.Semaphore()
 
                 def submain(): pass

--- a/pypy3.9/README_MODS
+++ b/pypy3.9/README_MODS
@@ -179,6 +179,17 @@ diff pypy3.9-v7.3.9-src/pypy/module/_multiprocessing/test/test_semaphore.py pypy
 167a174
 >     @pytest.mark.skipif(sys.platform == 'darwin', reason="Hangs on macOSX")
 # ----------------------------------------------------------------------
+diff pypy3.9-v7.3.15-src/lib-python/3/multiprocessing/managers.py pypy3.9-v7.3.16-src/lib-python/3/multiprocessing/managers.py
+721a722
+>                 conn.close()
+diff pypy3.9-v7.3.15-src/lib-python/3/multiprocessing/popen_spawn_win32.py pypy3.9-v7.3.16-src/lib-python/3/multiprocessing/popen_spawn_win32.py
+25c25,27
+< WINENV = not _path_eq(sys.executable, sys._base_executable)
+---
+> # PyPy is not affected by bpo-35797
+> # WINENV = not _path_eq(sys.executable, sys._base_executable)
+> WINENV = False
+# ----------------------------------------------------------------------
 NOTE: semaphore_tracker throws KeyError in multiprocess and multiprocessing
 
 Traceback (most recent call last):

--- a/pypy3.9/multiprocess/managers.py
+++ b/pypy3.9/multiprocess/managers.py
@@ -719,6 +719,7 @@ class BaseManager(object):
                     )
                 conn = self._Client(token.address, authkey=self._authkey)
                 dispatch(conn, None, 'decref', (token.id,))
+                conn.close()
                 return proxy
             temp.__name__ = typeid
             setattr(cls, typeid, temp)

--- a/pypy3.9/multiprocess/popen_spawn_win32.py
+++ b/pypy3.9/multiprocess/popen_spawn_win32.py
@@ -22,7 +22,9 @@ WINSERVICE = sys.executable.lower().endswith("pythonservice.exe")
 def _path_eq(p1, p2):
     return p1 == p2 or os.path.normcase(p1) == os.path.normcase(p2)
 
-WINENV = not _path_eq(sys.executable, sys._base_executable)
+# PyPy is not affected by bpo-35797
+# WINENV = not _path_eq(sys.executable, sys._base_executable)
+WINENV = False
 
 
 def _close_handles(*handles):


### PR DESCRIPTION
## Summary
Sync `multiprocess` with `multiprocessing` from python 3.12.5 and 3.13.0rc1, pypy-3.9 v7.3.16, and pypy-3.10 v7.3.17.

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.