### PR TITLE
enforce correct python tags for pure wheels from setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 # Further build requirements come from setup.py via the PEP 517 interface
 requires = [
+    "packaging",
     "setuptools>=42",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,7 @@ dill_version = 'dill>=0.3.9'
 
 def run_setup(with_extensions=True):
     extensions = []
+    options = {}
     if with_extensions:
         extensions = [
             Extension(
@@ -232,6 +233,14 @@ def run_setup(with_extensions=True):
                 depends=glob.glob('%s/*.h' % srcdir) + ['setup.py'],
             ),
         ]
+    else:
+        import packaging.tags
+
+        tag_name = packaging.tags.interpreter_name()
+        tag_version = packaging.tags.interpreter_version()
+        options['bdist_wheel'] = {
+            'python_tag':tag_name+tag_version,
+        }
     packages = find_packages(
         where=pkgdir,
         exclude=['ez_setup', 'examples', 'doc',],
@@ -276,6 +285,7 @@ def run_setup(with_extensions=True):
         packages=packages,
         package_dir={'': pkgdir},
         ext_modules=extensions,
+        options=options,
     )
     # add dependencies
     depend = [dill_version]


### PR DESCRIPTION
## Summary

Enforce correct python tags for pure Python wheels directly from `setup.py`.  This should be more reliable than the current approach. While at it, switch to correct tags for each platforms -- CPython uses "cp" (which unlike "py" is not accepted for PyPy), and PyPy can use pure "pp" without platform specifiers (since no extensions are installed).

Fixes #196

## Checklist

**Documentation and Tests**
- [x] Artifacts produced with the main branch work as expected under this PR.

**Release Management**
- [x] Added "Fixes #NNN" in the PR body, referencing the issue (#NNN) it closes.
- [ ] Added a comment to issue #NNN, linking back to this PR.
- [ ] Requested a review.