### PR TITLE
update for slow testing with pypy3.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,18 +37,18 @@ matrix:
           env:
             - PYPY_VERSION="3.9"
 
-        - python: 'pypy3.10-7.3.18'
+        - python: 'pypy3.10-7.3.19'
           env:
             - PYPY_VERSION="3.10"
 
-        - python: 'pypy3.11-7.3.18'
+        - python: 'pypy3.11-7.3.19'
           env:
             - PYPY_VERSION="3.11"
 
     allow_failures:
         - python: '3.14-dev' # CI missing
-        - python: 'pypy3.10-7.3.18' # CI missing
-        - python: 'pypy3.11-7.3.18' # CI missing
+        - python: 'pypy3.10-7.3.19' # CI missing
+        - python: 'pypy3.11-7.3.19' # CI missing
     fast_finish: true
 
 cache:
@@ -67,8 +67,8 @@ script:
     - if [[ $PYVERSION != "3.14" ]]; then PYVERSION=$TRAVIS_PYTHON_VERSION ; fi
     - if [[ $PYVERSION == "pypy3.8-7.3.9" ]]; then PYVERSION=py$PYPY_VERSION ; fi
     - if [[ $PYVERSION == "pypy3.9-7.3.9" ]]; then PYVERSION=py$PYPY_VERSION ; fi
-    - if [[ $PYVERSION == "pypy3.10-7.3.18" ]]; then PYVERSION=py$PYPY_VERSION ; fi
-    - if [[ $PYVERSION == "pypy3.11-7.3.18" ]]; then PYVERSION=py$PYPY_VERSION ; fi
+    - if [[ $PYVERSION == "pypy3.10-7.3.19" ]]; then PYVERSION=py$PYPY_VERSION ; fi
+    - if [[ $PYVERSION == "pypy3.11-7.3.19" ]]; then PYVERSION=py$PYPY_VERSION ; fi
     - cd py$PYVERSION #XXX: bash script may require tests run from root
     - if [[ $COVERAGE == "true" ]]; then cp ../.coveragerc .coveragerc ; fi
     - for test in multiprocess/tests/__init__.py; do echo $test ; if [[ $COVERAGE == "true" ]]; then coverage run -a $test > /dev/null; else python $test > /dev/null; fi ; done

--- a/pypy3.11/multiprocess/tests/__init__.py
+++ b/pypy3.11/multiprocess/tests/__init__.py
@@ -2100,6 +2100,7 @@ class _TestBarrier(BaseTestCase):
         except threading.BrokenBarrierError:
             results.append(True)
 
+    @unittest.skipIf(sys.implementation.name == 'pypy', 'poor timing for PyPy')
     def test_default_timeout(self):
         """
         Test the barrier's default timeout
@@ -2821,6 +2822,7 @@ class _TestPool(BaseTestCase):
         # check that we indeed waited for all jobs
         self.assertGreater(time.monotonic() - t_start, 0.9)
 
+    @unittest.skipIf(sys.implementation.name == 'pypy', 'poor timing for PyPy')
     def test_release_task_refs(self):
         # Issue #29861: task arguments and results should not be kept
         # alive after we are done with them.
@@ -3042,6 +3044,7 @@ class _TestMyManager(BaseTestCase):
         # which happens on slow buildbots.
         self.assertIn(manager._process.exitcode, (0, -signal.SIGTERM))
 
+    @unittest.skipIf(sys.implementation.name == 'pypy', 'poor timing for PyPy')
     def test_mymanager_context_prestarted(self):
         manager = MyManager(shutdown_timeout=SHUTDOWN_TIMEOUT)
         manager.start()


### PR DESCRIPTION
## Summary
update testing suite to account for pypy3.11 slowness

## Checklist
**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [ ] Added relevant documentation that builds in sphinx without error.
- [ ] Added new features that are documented with examples.
- [x] Artifacts produced with the main branch work as expected under this PR.
