### PR TITLE
sync with python 3.13.4

### DIFF
--- a/py3.13/README_MODS
+++ b/py3.13/README_MODS
@@ -1946,3 +1946,53 @@ diff Python-3.13.2/Lib/test/_test_multiprocessing.py Python-3.13.3/Lib/test/_tes
 >             # NOTE: join_process and join_thread are the same
 >             threading_helper.join_thread(w)
 > 
+# ----------------------------------------------------------------------
+diff Python-3.13.3/Lib/multiprocessing/context.py Python-3.13.4/Lib/multiprocessing/context.py
+148c148
+<         if sys.platform == 'win32' and getattr(sys, 'frozen', False):
+---
+>         if self.get_start_method() == 'spawn' and getattr(sys, 'frozen', False):
+diff Python-3.13.3/Lib/test/_test_multiprocessing.py Python-3.13.4/Lib/test/_test_multiprocessing.py 
+514a515,519
+>     def _sleep_some_event(cls, event):
+>         event.set()
+>         time.sleep(100)
+> 
+>     @classmethod
+522c527,528
+<         p = self.Process(target=self._sleep_some)
+---
+>         event = self.Event()
+>         p = self.Process(target=self._sleep_some_event, args=(event,))
+540,541c546,550
+<         # XXX maybe terminating too soon causes the problems on Gentoo...
+<         time.sleep(1)
+---
+>         timeout = support.SHORT_TIMEOUT
+>         if not event.wait(timeout):
+>             p.terminate()
+>             p.join()
+>             self.fail(f"event not signaled in {timeout} seconds")
+6487a6497,6518
+>     def test_forked_thread_not_started(self):
+>         # gh-134381: Ensure that a thread that has not been started yet in
+>         # the parent process can be started within a forked child process.
+> 
+>         if multiprocessing.get_start_method() != "fork":
+>             self.skipTest("fork specific test")
+> 
+>         q = multiprocessing.Queue()
+>         t = threading.Thread(target=lambda: q.put("done"), daemon=True)
+> 
+>         def child():
+>             t.start()
+>             t.join()
+> 
+>         p = multiprocessing.Process(target=child)
+>         p.start()
+>         p.join(support.SHORT_TIMEOUT)
+> 
+>         self.assertEqual(p.exitcode, 0)
+>         self.assertEqual(q.get_nowait(), "done")
+>         close_queue(q)
+> 

--- a/py3.13/multiprocess/context.py
+++ b/py3.13/multiprocess/context.py
@@ -145,7 +145,7 @@ class BaseContext(object):
         '''Check whether this is a fake forked process in a frozen executable.
         If so then run code specified by commandline and exit.
         '''
-        if sys.platform == 'win32' and getattr(sys, 'frozen', False):
+        if self.get_start_method() == 'spawn' and getattr(sys, 'frozen', False):
             from .spawn import freeze_support
             freeze_support()
 

--- a/py3.13/multiprocess/tests/__init__.py
+++ b/py3.13/multiprocess/tests/__init__.py
@@ -6511,6 +6511,7 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual("332833500", out.decode('utf-8').strip())
         self.assertFalse(err, msg=err.decode('utf-8'))
 
+    @unittest.skipIf(sys.hexversion <= 0x30d03f0, "added in 3.13.4")
     def test_forked_thread_not_started(self):
         # gh-134381: Ensure that a thread that has not been started yet in
         # the parent process can be started within a forked child process.

--- a/py3.13/multiprocess/tests/__init__.py
+++ b/py3.13/multiprocess/tests/__init__.py
@@ -519,6 +519,11 @@ class _TestProcess(BaseTestCase):
         time.sleep(100)
 
     @classmethod
+    def _sleep_some_event(cls, event):
+        event.set()
+        time.sleep(100)
+
+    @classmethod
     def _test_sleep(cls, delay):
         time.sleep(delay)
 
@@ -526,7 +531,8 @@ class _TestProcess(BaseTestCase):
         if self.TYPE == 'threads':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-        p = self.Process(target=self._sleep_some)
+        event = self.Event()
+        p = self.Process(target=self._sleep_some_event, args=(event,))
         p.daemon = True
         p.start()
 
@@ -544,8 +550,11 @@ class _TestProcess(BaseTestCase):
         self.assertTimingAlmostEqual(join.elapsed, 0.0)
         self.assertEqual(p.is_alive(), True)
 
-        # XXX maybe terminating too soon causes the problems on Gentoo...
-        time.sleep(1)
+        timeout = support.SHORT_TIMEOUT
+        if not event.wait(timeout):
+            p.terminate()
+            p.join()
+            self.fail(f"event not signaled in {timeout} seconds")
 
         meth(p)
 
@@ -6501,6 +6510,28 @@ class MiscTestCase(unittest.TestCase):
         rc, out, err = script_helper.assert_python_ok(testfn)
         self.assertEqual("332833500", out.decode('utf-8').strip())
         self.assertFalse(err, msg=err.decode('utf-8'))
+
+    def test_forked_thread_not_started(self):
+        # gh-134381: Ensure that a thread that has not been started yet in
+        # the parent process can be started within a forked child process.
+
+        if multiprocessing.get_start_method() != "fork":
+            self.skipTest("fork specific test")
+            
+        q = multiprocessing.Queue()
+        t = threading.Thread(target=lambda: q.put("done"), daemon=True)
+            
+        def child():
+            t.start()
+            t.join()
+
+        p = multiprocessing.Process(target=child)
+        p.start()
+        p.join(support.SHORT_TIMEOUT)
+
+        self.assertEqual(p.exitcode, 0)
+        self.assertEqual(q.get_nowait(), "done")
+        close_queue(q)
 
 
 #

--- a/py3.14/multiprocess/tests/__init__.py
+++ b/py3.14/multiprocess/tests/__init__.py
@@ -6850,6 +6850,7 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual("332833500", out.decode('utf-8').strip())
         self.assertFalse(err, msg=err.decode('utf-8'))
 
+    @unittest.skipIf(sys.hexversion <= 0x30e00b1, "added in 3.14.0b2")
     def test_forked_thread_not_started(self):
         # gh-134381: Ensure that a thread that has not been started yet in
         # the parent process can be started within a forked child process.


### PR DESCRIPTION
## Summary
Sync `multiprocess` with `multiprocessing` from python 3.13.4

## Checklist

**Documentation and Tests**
- [x] Added relevant tests that run with `python tests/__main__.py`, and pass.
- [x] Artifacts produced with the main branch work as expected under this PR.
