### PR TITLE
use dummy decorator if warnings_helper not found

### DIFF
--- a/py3.15/multiprocess/tests/__init__.py
+++ b/py3.15/multiprocess/tests/__init__.py
@@ -50,11 +50,11 @@ import threading
 # Skip warnings decorator if not found in warnings_helper.
 warnings_helper_ignore_fork_in_thread_deprecation_warnings = getattr(warnings_helper, 'ignore_fork_in_thread_deprecation_warnings', None)
 if warnings_helper_ignore_fork_in_thread_deprecation_warnings is None:
-    from contextlib import contextmanager, nullcontext
-    @contextmanager
+    HAS_WARN = False
+    @unittest.skipIf(True, "skip warning not found")
     def warnings_helper_ignore_fork_in_thread_deprecation_warnings():
-        with nullcontext():
-            yield
+        yield
+else: HAS_WARN = True
 
 import multiprocess as multiprocessing
 import multiprocess.connection
@@ -2870,7 +2870,11 @@ class _TestPool(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        if HAS_WARN:
+            with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+                super().setUpClass()
+                cls.pool = cls.Pool(4)
+        else:
             super().setUpClass()
             cls.pool = cls.Pool(4)
 
@@ -3603,7 +3607,10 @@ class FakeConnection:
 class TestManagerExceptions(unittest.TestCase):
     # Issue 106558: Manager exceptions avoids creating cyclic references.
     def setUp(self):
-        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        if HAS_WARN:
+            with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+                self.mgr = multiprocessing.Manager()
+        else:
             self.mgr = multiprocessing.Manager()
 
     def tearDown(self):
@@ -5418,7 +5425,12 @@ def initializer(ns):
 @hashlib_helper.requires_hashdigest('sha256')
 class TestInitializers(unittest.TestCase):
     def setUp(self):
-        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        if HAS_WARN:
+            with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+                self.mgr = multiprocessing.Manager()
+                self.ns = self.mgr.Namespace()
+                self.ns.test = 0
+        else:
             self.mgr = multiprocessing.Manager()
             self.ns = self.mgr.Namespace()
             self.ns.test = 0
@@ -6479,7 +6491,10 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     def setUp(self):
         self.manager = self.manager_class()
-        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        if HAS_WARN:
+            with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+                self.manager.start()
+        else:
             self.manager.start()
         self.proc = None
 
@@ -7212,7 +7227,11 @@ class ManagerMixin(BaseMixin):
 
     @classmethod
     def setUpClass(cls):
-        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        if HAS_WARN:
+            with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+                super().setUpClass()
+                cls.manager = multiprocessing.Manager()
+        else:
             super().setUpClass()
             cls.manager = multiprocessing.Manager()
 

--- a/py3.15/multiprocess/tests/__init__.py
+++ b/py3.15/multiprocess/tests/__init__.py
@@ -50,12 +50,11 @@ import threading
 # Skip warnings decorator if not found in warnings_helper.
 warnings_helper_ignore_fork_in_thread_deprecation_warnings = getattr(warnings_helper, 'ignore_fork_in_thread_deprecation_warnings', None)
 if warnings_helper_ignore_fork_in_thread_deprecation_warnings is None:
-    from contextlib import ContextDecorator
-    class warnings_helper_ignore_fork_in_thread_deprecation_warnings(ContextDecorator):
-        def __enter__(self):
-            return self
-        def __exit__(self, exc_type, exc_val, exc_tb):
-            return
+    from contextlib import contextmanager, nullcontext
+    @contextmanager
+    def warnings_helper_ignore_fork_in_thread_deprecation_warnings():
+        with nullcontext():
+            yield
 
 import multiprocess as multiprocessing
 import multiprocess.connection

--- a/py3.15/multiprocess/tests/__init__.py
+++ b/py3.15/multiprocess/tests/__init__.py
@@ -47,6 +47,15 @@ _multiprocessing = import_helper.import_module('_multiprocessing')
 # Skip tests if sem_open implementation is broken.
 import_helper.import_module('multiprocess.synchronize')
 import threading
+# Skip warnings decorator if not found in warnings_helper.
+warnings_helper_ignore_fork_in_thread_deprecation_warnings = getattr(warnings_helper, 'ignore_fork_in_thread_deprecation_warnings', None)
+if warnings_helper_ignore_fork_in_thread_deprecation_warnings is None:
+    from contextlib import ContextDecorator
+    class warnings_helper_ignore_fork_in_thread_deprecation_warnings(ContextDecorator):
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            return
 
 import multiprocess as multiprocessing
 import multiprocess.connection
@@ -333,7 +342,7 @@ class _TestProcess(BaseTestCase):
         self.assertEqual(current.ident, os.getpid())
         self.assertEqual(current.exitcode, None)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_set_executable(self):
         if self.TYPE == 'threads':
             self.skipTest(f'test not appropriate for {self.TYPE}')
@@ -350,7 +359,7 @@ class _TestProcess(BaseTestCase):
             p.join()
             self.assertEqual(p.exitcode, 0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.requires_resource('cpu')
     def test_args_argument(self):
         # bpo-45735: Using list or tuple as *args* in constructor could
@@ -398,7 +407,7 @@ class _TestProcess(BaseTestCase):
             q.put(bytes(current.authkey))
             q.put(current.pid)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_parent_process_attributes(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -419,7 +428,7 @@ class _TestProcess(BaseTestCase):
         from multiprocess.process import parent_process
         wconn.send([parent_process().pid, parent_process().name])
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def _test_parent_process(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -458,7 +467,7 @@ class _TestProcess(BaseTestCase):
         parent_process().join(timeout=support.SHORT_TIMEOUT)
         wconn.send("alive" if parent_process().is_alive() else "not alive")
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_process(self):
         q = self.Queue(1)
         e = self.Event()
@@ -499,7 +508,7 @@ class _TestProcess(BaseTestCase):
         self.assertNotIn(p, self.active_children())
         close_queue(q)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(threading._HAVE_THREAD_NATIVE_ID, "needs native_id")
     def test_process_mainthread_native_id(self):
         if self.TYPE == 'threads':
@@ -540,7 +549,7 @@ class _TestProcess(BaseTestCase):
     def _test_sleep(cls, delay):
         time.sleep(delay)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def _kill_process(self, meth, target=None):
         if self.TYPE == 'threads':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -598,7 +607,7 @@ class _TestProcess(BaseTestCase):
 
         return p.exitcode
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(os.name == 'nt', "POSIX only")
     def test_interrupt(self):
         exitcode = self._kill_process(multiprocessing.Process.interrupt)
@@ -607,18 +616,18 @@ class _TestProcess(BaseTestCase):
         # (KeyboardInterrupt in this case)
         # in multiprocessing.BaseProcess._bootstrap
         
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(os.name == 'nt', "POSIX only")
     def test_interrupt_no_handler(self):
         exitcode = self._kill_process(multiprocessing.Process.interrupt, target=self._sleep_no_int_handler)
         self.assertEqual(exitcode, -signal.SIGINT)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_terminate(self):
         exitcode = self._kill_process(multiprocessing.Process.terminate)
         self.assertEqual(exitcode, -signal.SIGTERM)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_kill(self):
         exitcode = self._kill_process(multiprocessing.Process.kill)
         if os.name != 'nt':
@@ -634,7 +643,7 @@ class _TestProcess(BaseTestCase):
         self.assertIsInstance(cpus, int)
         self.assertGreaterEqual(cpus, 1)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_active_children(self):
         self.assertEqual(type(self.active_children()), list)
 
@@ -663,7 +672,7 @@ class _TestProcess(BaseTestCase):
                 p.start()
                 p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(True, "fails with is_dill(obj, child=True)")
     def test_recursion(self):
         rconn, wconn = self.Pipe(duplex=False)
@@ -689,7 +698,7 @@ class _TestProcess(BaseTestCase):
     def _test_sentinel(cls, event):
         event.wait(10.0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_sentinel(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -712,7 +721,7 @@ class _TestProcess(BaseTestCase):
             q.get()
         sys.exit(rc)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_close(self):
         if self.TYPE == "threads":
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -745,7 +754,7 @@ class _TestProcess(BaseTestCase):
 
         close_queue(q)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.requires_resource('walltime')
     def test_many_processes(self):
         if self.TYPE == 'threads':
@@ -783,7 +792,7 @@ class _TestProcess(BaseTestCase):
             for p in procs:
                 self.assertIn(p.exitcode, exitcodes)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_lose_target_ref(self):
         c = DummyCallable()
         wr = weakref.ref(c)
@@ -846,7 +855,7 @@ class _TestProcess(BaseTestCase):
         threading.Thread(target=func1).start()
         threading.Thread(target=func2, daemon=True).start()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_wait_for_threads(self):
         # A child process should wait for non-daemonic threads to end
         # before exiting
@@ -871,7 +880,7 @@ class _TestProcess(BaseTestCase):
             setattr(sys, stream_name, None)
         evt.set()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_error_on_stdio_flush_1(self):
         # Check that Process works with broken standard streams
         streams = [io.StringIO(), None]
@@ -891,7 +900,7 @@ class _TestProcess(BaseTestCase):
                 finally:
                     setattr(sys, stream_name, old_stream)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_error_on_stdio_flush_2(self):
         # Same as test_error_on_stdio_flush_1(), but standard streams are
         # broken by the child process
@@ -1042,7 +1051,7 @@ class _TestSubclassingProcess(BaseTestCase):
 
     ALLOWED_TYPES = ('processes',)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_subclassing(self):
         uppercaser = _UpperCaser()
         uppercaser.daemon = True
@@ -1052,7 +1061,7 @@ class _TestSubclassingProcess(BaseTestCase):
         uppercaser.stop()
         uppercaser.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_stderr_flush(self):
         # sys.stderr is flushed at process shutdown (issue #13812)
         if self.TYPE == "threads":
@@ -1083,7 +1092,7 @@ class _TestSubclassingProcess(BaseTestCase):
         sys.stderr = open(fd, 'w', encoding="utf-8", closefd=False)
         sys.exit(reason)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_sys_exit(self):
         # See Issue 13854
         if self.TYPE == 'threads':
@@ -1151,7 +1160,7 @@ class _TestQueue(BaseTestCase):
             queue.get()
         parent_can_continue.set()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_put(self):
         MAXSIZE = 6
         queue = self.Queue(maxsize=MAXSIZE)
@@ -1221,7 +1230,7 @@ class _TestQueue(BaseTestCase):
         queue.put(5)
         parent_can_continue.set()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_get(self):
         queue = self.Queue()
         child_can_start = self.Event()
@@ -1284,7 +1293,7 @@ class _TestQueue(BaseTestCase):
         # process cannot shutdown until the feeder thread has finished
         # pushing items onto the pipe.
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_fork(self):
         # Old versions of Queue would fail to create a new feeder
         # thread for a forked process if the original process had its
@@ -1335,7 +1344,7 @@ class _TestQueue(BaseTestCase):
             time.sleep(DELTA)
             q.task_done()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_task_done(self):
         queue = self.JoinableQueue()
 
@@ -1379,7 +1388,7 @@ class _TestQueue(BaseTestCase):
                     self.fail("Probable regression on import lock contention;"
                               " see Issue #22853")
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_timeout(self):
         q = multiprocessing.Queue()
         start = time.monotonic()
@@ -1503,7 +1512,7 @@ class _TestLock(BaseTestCase):
         event.set()
         time.sleep(1.0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_repr_lock(self):
         if self.TYPE != 'processes':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -1567,7 +1576,7 @@ class _TestLock(BaseTestCase):
         res.value = lock.locked()
         event.set()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_SHAREDCTYPES, 'needs sharedctypes')
     def test_lock_locked_2processes(self):
         if self.TYPE != 'processes':
@@ -1594,7 +1603,7 @@ class _TestLock(BaseTestCase):
         for _ in range(n):
             lock.release()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_repr_rlock(self):
         if self.TYPE != 'processes':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -1654,7 +1663,7 @@ class _TestLock(BaseTestCase):
         if sys.hexversion > 0x30e00a6: self.assertFalse(lock.locked())
         self.assertRaises((AssertionError, RuntimeError), lock.release)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_SHAREDCTYPES, 'needs sharedctypes')
     def test_rlock_locked_2processes(self):
         if self.TYPE != 'processes':
@@ -1766,7 +1775,7 @@ class _TestCondition(BaseTestCase):
             except NotImplementedError:
                 pass
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_notify(self):
         cond = self.Condition()
         sleeping = self.Semaphore(0)
@@ -1809,7 +1818,7 @@ class _TestCondition(BaseTestCase):
         threading_helper.join_thread(t)
         join_process(p)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_notify_all(self):
         cond = self.Condition()
         sleeping = self.Semaphore(0)
@@ -1879,7 +1888,7 @@ class _TestCondition(BaseTestCase):
             # NOTE: join_process and join_thread are the same
             threading_helper.join_thread(w)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_notify_n(self):
         cond = self.Condition()
         sleeping = self.Semaphore(0)
@@ -1953,7 +1962,7 @@ class _TestCondition(BaseTestCase):
             if not result or state.value != 4:
                 sys.exit(1)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_SHAREDCTYPES, 'needs sharedctypes')
     def test_waitfor(self):
         # based on test in test/lock_tests.py
@@ -1989,7 +1998,7 @@ class _TestCondition(BaseTestCase):
             if not result and (expected - CLOCK_RES) <= dt:
                 success.value = True
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_SHAREDCTYPES, 'needs sharedctypes')
     def test_waitfor_timeout(self):
         # based on test in test/lock_tests.py
@@ -2022,7 +2031,7 @@ class _TestCondition(BaseTestCase):
         if pid is not None:
             os.kill(pid, signal.SIGINT)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_wait_result(self):
         if isinstance(self, ProcessesMixin) and sys.platform != 'win32':
             pid = os.getpid()
@@ -2051,7 +2060,7 @@ class _TestEvent(BaseTestCase):
         time.sleep(TIMEOUT2)
         event.set()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_event(self):
         event = self.Event()
         wait = TimingWrapper(event.wait)
@@ -2248,7 +2257,7 @@ class _TestBarrier(BaseTestCase):
             pass
         assert not barrier.broken
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_barrier(self, passes=1):
         """
         Test that a barrier is passed in lockstep
@@ -2256,7 +2265,7 @@ class _TestBarrier(BaseTestCase):
         results = [self.DummyList(), self.DummyList()]
         self.run_threads(self.multipass, (self.barrier, results, passes))
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_barrier_10(self):
         """
         Test that a barrier works for 10 consecutive runs
@@ -2268,7 +2277,7 @@ class _TestBarrier(BaseTestCase):
         res = barrier.wait()
         queue.put(res)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_wait_return(self):
         """
         test the return value from barrier.wait
@@ -2285,7 +2294,7 @@ class _TestBarrier(BaseTestCase):
         if len(results) != 1:
             raise RuntimeError
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_action(self):
         """
         Test the 'action' callback
@@ -2308,7 +2317,7 @@ class _TestBarrier(BaseTestCase):
         except RuntimeError:
             barrier.abort()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_abort(self):
         """
         Test that an abort will put the barrier in a broken state
@@ -2339,7 +2348,7 @@ class _TestBarrier(BaseTestCase):
         barrier.wait()
         results3.append(True)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_reset(self):
         """
         Test that a 'reset' on a barrier frees the waiting threads
@@ -2375,7 +2384,7 @@ class _TestBarrier(BaseTestCase):
         barrier.wait()
         results3.append(True)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_abort_and_reset(self):
         """
         Test that a barrier can be reset after being broken.
@@ -2402,7 +2411,7 @@ class _TestBarrier(BaseTestCase):
         except threading.BrokenBarrierError:
             results.append(True)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_timeout(self):
         """
         Test wait(timeout)
@@ -2422,7 +2431,7 @@ class _TestBarrier(BaseTestCase):
         except threading.BrokenBarrierError:
             results.append(True)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_default_timeout(self):
         """
         Test the barrier's default timeout
@@ -2444,7 +2453,7 @@ class _TestBarrier(BaseTestCase):
             with lock:
                 conn.send(i)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_thousand(self):
         if self.TYPE == 'manager':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
@@ -2486,7 +2495,7 @@ class _TestValue(BaseTestCase):
         for sv, cv in zip(values, cls.codes_values):
             sv.value = cv[2]
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_value(self, raw=False):
         if raw:
             values = [self.RawValue(code, value)
@@ -2550,7 +2559,7 @@ class _TestArray(BaseTestCase):
         for i in range(1, len(seq)):
             seq[i] += seq[i-1]
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(c_int is None, "requires _ctypes")
     def test_array(self, raw=False):
         seq = [680, 626, 934, 821, 150, 233, 548, 982, 714, 831]
@@ -2862,7 +2871,7 @@ class _TestPool(BaseTestCase):
 
     @classmethod
     def setUpClass(cls):
-        with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
             super().setUpClass()
             cls.pool = cls.Pool(4)
 
@@ -2963,7 +2972,7 @@ class _TestPool(BaseTestCase):
         self.assertEqual(get(), 49)
         self.assertTimingAlmostEqual(get.elapsed, TIMEOUT1)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_async_timeout(self):
         p = self.Pool(3)
         try:
@@ -3061,7 +3070,7 @@ class _TestPool(BaseTestCase):
                 self.assertIn(value, expected_values)
                 expected_values.remove(value)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_make_pool(self):
         expected_error = (RemoteError if self.TYPE == 'manager'
                           else ValueError)
@@ -3077,7 +3086,7 @@ class _TestPool(BaseTestCase):
                 p.close()
                 p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_terminate(self):
         # Simulate slow tasks which take "forever" to complete
         sleep_time = support.LONG_TIMEOUT
@@ -3095,7 +3104,7 @@ class _TestPool(BaseTestCase):
         p.terminate()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_empty_iterable(self):
         # See Issue 12157
         p = self.Pool(1)
@@ -3108,7 +3117,7 @@ class _TestPool(BaseTestCase):
         p.close()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_context(self):
         if self.TYPE == 'processes':
             L = list(range(10))
@@ -3123,7 +3132,7 @@ class _TestPool(BaseTestCase):
     def _test_traceback(cls):
         raise RuntimeError(123) # some comment
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(True, "fails with is_dill(obj, child=True)")
     def test_traceback(self):
         # We want ensure that the traceback from the child process is
@@ -3164,11 +3173,11 @@ class _TestPool(BaseTestCase):
             p.join()
 
     @classmethod
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def _test_wrapped_exception(cls):
         raise RuntimeError('foo')
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(True, "fails with is_dill(obj, child=True)")
     def test_wrapped_exception(self):
         # Issue #20980: Should not wrap exception when using thread pool
@@ -3177,7 +3186,7 @@ class _TestPool(BaseTestCase):
                 p.apply(self._test_wrapped_exception)
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_map_no_failfast(self):
         # Issue #23992: the fail-fast behaviour when an exception is raised
         # during map() would make Pool.join() deadlock, because a worker
@@ -3213,7 +3222,7 @@ class _TestPool(BaseTestCase):
         # they were released too.
         self.assertEqual(CountedObject.n_instances, 0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_enter(self):
         if self.TYPE == 'manager':
             self.skipTest("test not applicable to manager")
@@ -3230,7 +3239,7 @@ class _TestPool(BaseTestCase):
                 pass
         pool.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_resource_warning(self):
         if self.TYPE == 'manager':
             self.skipTest("test not applicable to manager")
@@ -3256,7 +3265,7 @@ def unpickleable_result():
 class _TestPoolWorkerErrors(BaseTestCase):
     ALLOWED_TYPES = ('processes', )
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_async_error_callback(self):
         p = multiprocessing.Pool(2)
 
@@ -3272,7 +3281,7 @@ class _TestPoolWorkerErrors(BaseTestCase):
         p.close()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def _test_unpickleable_result(self):
         from multiprocess.pool import MaybeEncodingError
         p = multiprocessing.Pool(2)
@@ -3298,7 +3307,7 @@ class _TestPoolWorkerErrors(BaseTestCase):
 class _TestPoolWorkerLifetime(BaseTestCase):
     ALLOWED_TYPES = ('processes', )
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pool_worker_lifetime(self):
         p = multiprocessing.Pool(3, maxtasksperchild=10)
         self.assertEqual(3, len(p._pool))
@@ -3328,7 +3337,7 @@ class _TestPoolWorkerLifetime(BaseTestCase):
         p.close()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pool_worker_lifetime_early_close(self):
         # Issue #10332: closing a pool whose workers have limited lifetimes
         # before all the tasks completed would make join() hang.
@@ -3402,7 +3411,7 @@ class _TestMyManager(BaseTestCase):
 
     ALLOWED_TYPES = ('manager',)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.skip_if_sanitizer('TSan: leaks threads', thread=True)
     def test_mymanager(self):
         manager = MyManager(shutdown_timeout=SHUTDOWN_TIMEOUT)
@@ -3415,7 +3424,7 @@ class _TestMyManager(BaseTestCase):
         # which happens on slow buildbots.
         self.assertIn(manager._process.exitcode, (0, -signal.SIGTERM))
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.skip_if_sanitizer('TSan: leaks threads', thread=True)
     def test_mymanager_context(self):
         manager = MyManager(shutdown_timeout=SHUTDOWN_TIMEOUT)
@@ -3426,7 +3435,7 @@ class _TestMyManager(BaseTestCase):
         # which happens on slow buildbots.
         self.assertIn(manager._process.exitcode, (0, -signal.SIGTERM))
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.skip_if_sanitizer('TSan: leaks threads', thread=True)
     def test_mymanager_context_prestarted(self):
         manager = MyManager(shutdown_timeout=SHUTDOWN_TIMEOUT)
@@ -3498,7 +3507,7 @@ class _TestRemoteManager(BaseTestCase):
         # Note that xmlrpclib will deserialize object as a list not a tuple
         queue.put(tuple(cls.values))
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.skip_if_sanitizer('TSan: leaks threads', thread=True)
     def test_remote(self):
         authkey = os.urandom(32)
@@ -3541,7 +3550,7 @@ class _TestManagerRestart(BaseTestCase):
         queue = manager.get_queue()
         queue.put('hello world')
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.skip_if_sanitizer("TSan: leaks threads", thread=True)
     def test_rapid_restart(self):
         authkey = os.urandom(32)
@@ -3595,14 +3604,14 @@ class FakeConnection:
 class TestManagerExceptions(unittest.TestCase):
     # Issue 106558: Manager exceptions avoids creating cyclic references.
     def setUp(self):
-        with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
             self.mgr = multiprocessing.Manager()
 
     def tearDown(self):
         self.mgr.shutdown()
         self.mgr.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_queue_get(self):
         queue = self.mgr.Queue()
         if gc.isenabled():
@@ -3614,7 +3623,7 @@ class TestManagerExceptions(unittest.TestCase):
             wr = weakref.ref(e)
         self.assertEqual(wr(), None)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_dispatch(self):
         if gc.isenabled():
             gc.disable()
@@ -3641,7 +3650,7 @@ class _TestConnection(BaseTestCase):
             conn.send_bytes(msg)
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_connection(self):
         conn, child_conn = self.Pipe()
 
@@ -3734,7 +3743,7 @@ class _TestConnection(BaseTestCase):
             self.assertRaises(OSError, writer.recv)
             self.assertRaises(OSError, writer.poll)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_spawn_close(self):
         # We test that a pipe connection can be closed by parent
         # process immediately after child is spawned.  On Windows this
@@ -3811,7 +3820,7 @@ class _TestConnection(BaseTestCase):
         os.write(fd, data)
         os.close(fd)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
     def test_fd_transfer(self):
         if self.TYPE != 'processes':
@@ -3831,7 +3840,7 @@ class _TestConnection(BaseTestCase):
         with open(os_helper.TESTFN, "rb") as f:
             self.assertEqual(f.read(), b"foo")
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
     @unittest.skipIf(sys.platform == "win32",
                      "test semantics don't make sense on Windows")
@@ -3869,7 +3878,7 @@ class _TestConnection(BaseTestCase):
     def _send_data_without_fd(self, conn):
         os.write(conn.fileno(), b"\0")
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
     @unittest.skipIf(sys.platform == "win32", "doesn't make sense on Windows")
     def test_missing_fd_transfer(self):
@@ -3969,7 +3978,7 @@ class _TestListenerClient(BaseTestCase):
         conn.send('hello')
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_listener_client(self):
         for family in self.connection.families:
             l = self.connection.Listener(family=family)
@@ -3981,7 +3990,7 @@ class _TestListenerClient(BaseTestCase):
             p.join()
             l.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_issue14725(self):
         l = self.connection.Listener()
         p = self.Process(target=self._test, args=(l.address,))
@@ -4027,7 +4036,7 @@ class _TestPoll(BaseTestCase):
             conn.send_bytes(s)
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_strings(self):
         strings = (b'hello', b'', b'a', b'b', b'', b'bye', b'', b'lop')
         a, b = self.Pipe()
@@ -4051,7 +4060,7 @@ class _TestPoll(BaseTestCase):
         # read from it.
         r.poll(5)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_boundaries(self):
         r, w = self.Pipe(False)
         p = self.Process(target=self._child_boundaries, args=(r,))
@@ -4070,7 +4079,7 @@ class _TestPoll(BaseTestCase):
         b.send_bytes(b'b')
         b.send_bytes(b'cd')
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_dont_merge(self):
         a, b = self.Pipe()
         self.assertEqual(a.poll(0.0), False)
@@ -4139,7 +4148,7 @@ class _TestPicklingConnections(BaseTestCase):
 
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pickling(self):
         families = self.connection.families
 
@@ -4198,7 +4207,7 @@ class _TestPicklingConnections(BaseTestCase):
 
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_access(self):
         # On Windows, if we do not specify a destination pid when
         # using DupHandle then we need to be careful to use the
@@ -4362,7 +4371,7 @@ class _TestSharedCTypes(BaseTestCase):
         for i in range(len(arr)):
             arr[i] *= 2
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_sharedctypes(self, lock=False):
         x = Value('i', 7, lock=lock)
         y = Value(c_double, 1.0/3.0, lock=lock)
@@ -4639,7 +4648,7 @@ class _TestSharedMemory(BaseTestCase):
                 with self.assertRaises(FileNotFoundError):
                     pickle.loads(pickled_sms)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_shared_memory_across_processes(self):
         # bpo-40135: don't define shared memory block's name in case of
         # the failure when we run multiprocessing tests in parallel.
@@ -4668,7 +4677,7 @@ class _TestSharedMemory(BaseTestCase):
 
         sms.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(os.name != "posix", "not feasible in non-posix platforms")
     def test_shared_memory_SharedMemoryServer_ignores_sigint(self):
         # bpo-36368: protect SharedMemoryManager server process from
@@ -4715,7 +4724,7 @@ class _TestSharedMemory(BaseTestCase):
         # properly released sl.
         self.assertFalse(err)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_shared_memory_SharedMemoryManager_basics(self):
         smm1 = multiprocessing.managers.SharedMemoryManager()
         with self.assertRaises(ValueError):
@@ -5057,7 +5066,7 @@ class _TestFinalize(BaseTestCase):
         conn.close()
         os._exit(0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_finalize(self):
         conn, child_conn = self.Pipe()
 
@@ -5185,7 +5194,7 @@ class _TestLogging(BaseTestCase):
         logger = multiprocessing.get_logger()
         conn.send(logger.getEffectiveLevel())
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_level(self):
         LEVEL1 = 32
         LEVEL2 = 37
@@ -5270,7 +5279,7 @@ class _TestPollEintr(BaseTestCase):
         time.sleep(0.1)
         os.kill(pid, signal.SIGUSR1)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(hasattr(signal, 'SIGUSR1'), 'requires SIGUSR1')
     def test_poll_eintr(self):
         got_signal = [False]
@@ -5410,7 +5419,7 @@ def initializer(ns):
 @hashlib_helper.requires_hashdigest('sha256')
 class TestInitializers(unittest.TestCase):
     def setUp(self):
-        with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
             self.mgr = multiprocessing.Manager()
             self.ns = self.mgr.Namespace()
             self.ns.test = 0
@@ -5419,7 +5428,7 @@ class TestInitializers(unittest.TestCase):
         self.mgr.shutdown()
         self.mgr.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_manager_initializer(self):
         m = multiprocessing.managers.SyncManager()
         self.assertRaises(TypeError, m.start, 1)
@@ -5428,7 +5437,7 @@ class TestInitializers(unittest.TestCase):
         m.shutdown()
         m.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pool_initializer(self):
         self.assertRaises(TypeError, multiprocessing.Pool, initializer=1)
         p = multiprocessing.Pool(1, initializer, (self.ns,))
@@ -5486,19 +5495,19 @@ class _file_like(object):
 
 class TestStdinBadfiledescriptor(unittest.TestCase):
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_queue_in_process(self):
         proc = multiprocessing.Process(target=_test_process)
         proc.start()
         proc.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pool_in_process(self):
         p = multiprocessing.Process(target=pool_in_process)
         p.start()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_flushing(self):
         sio = io.StringIO()
         flike = _file_like(sio)
@@ -5518,7 +5527,7 @@ class TestWait(unittest.TestCase):
             w.send((i, os.getpid()))
         w.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_wait(self, slow=False):
         from multiprocess.connection import wait
         readers = []
@@ -5559,7 +5568,7 @@ class TestWait(unittest.TestCase):
             s.sendall(('%s\n' % i).encode('ascii'))
         s.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_wait_socket(self, slow=False):
         from multiprocess.connection import wait
         l = socket.create_server((socket_helper.HOST, 0))
@@ -5624,7 +5633,7 @@ class TestWait(unittest.TestCase):
         sem.release()
         time.sleep(period)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @support.requires_resource('walltime')
     def test_wait_integer(self):
         from multiprocess.connection import wait
@@ -5669,7 +5678,7 @@ class TestWait(unittest.TestCase):
         p.terminate()
         p.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_neg_timeout(self):
         from multiprocess.connection import wait
         a, b = multiprocessing.Pipe()
@@ -5747,7 +5756,7 @@ class TestTimeouts(unittest.TestCase):
         conn.send(456)
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_timeout(self):
         old_timeout = socket.getdefaulttimeout()
         try:
@@ -5805,7 +5814,7 @@ class TestForkAwareThreadLock(unittest.TestCase):
             conn.send(len(util._afterfork_registry))
         conn.close()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_lock(self):
         r, w = multiprocessing.Pipe(False)
         l = util.ForkAwareThreadLock()
@@ -5857,7 +5866,7 @@ class TestCloseFds(unittest.TestCase):
             s.close()
             conn.send(None)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_closefd(self):
         if not HAS_REDUCTION:
             raise unittest.SkipTest('requires fd pickling')
@@ -5903,7 +5912,7 @@ class TestIgnoreEINTR(unittest.TestCase):
         conn.send(x)
         conn.send_bytes(b'x' * cls.CONN_MAX_SIZE)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(hasattr(signal, 'SIGUSR1'), 'requires SIGUSR1')
     def test_ignore(self):
         conn, child_conn = multiprocessing.Pipe()
@@ -5937,7 +5946,7 @@ class TestIgnoreEINTR(unittest.TestCase):
             a = l.accept()
             a.send('welcome')
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipUnless(hasattr(signal, 'SIGUSR1'), 'requires SIGUSR1')
     def test_ignore_listener(self):
         conn, child_conn = multiprocessing.Pipe()
@@ -5972,7 +5981,7 @@ class TestStartMethod(unittest.TestCase):
         p.join()
         self.assertEqual(child_method, ctx.get_start_method())
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_context(self):
         for method in ('fork', 'spawn', 'forkserver'):
             try:
@@ -5989,7 +5998,7 @@ class TestStartMethod(unittest.TestCase):
     def _dummy_func():
         pass
             
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_spawn_dont_set_context(self):
         # Run a process with spawn or forkserver context may change
         # the global start method, see gh-109263.
@@ -6013,7 +6022,7 @@ class TestStartMethod(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, 'module_names must be a list of strings'):
             ctx.set_forkserver_preload([1, 2, 3])
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_set_get(self):
         multiprocessing.set_forkserver_preload(PRELOAD)
         count = 0
@@ -6071,7 +6080,7 @@ class TestStartMethod(unittest.TestCase):
             print(err)
             self.fail("failed spawning forkserver or grandchild")
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(sys.platform == "win32",
                      "Only Spawn on windows so no risk of mixing")
     @only_run_in_spawn_testsuite("avoids redundant testing.")
@@ -6105,7 +6114,7 @@ class TestStartMethod(unittest.TestCase):
         process.start()
         process.join()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_nested_startmethod(self):
         # gh-108520: Regression test to ensure that child process can send its
         # arguments to another process
@@ -6261,7 +6270,7 @@ class TestResourceTracker(unittest.TestCase):
         reused &= _resource_tracker._check_alive()
         conn.send(reused)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_resource_tracker_reused(self):
         from multiprocess.resource_tracker import _resource_tracker
         _resource_tracker.ensure_running()
@@ -6363,7 +6372,7 @@ class TestSimpleQueue(unittest.TestCase):
         with self.assertRaisesRegex(OSError, 'is closed'):
             q.empty()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_empty(self):
         queue = multiprocessing.SimpleQueue()
         child_can_start = multiprocessing.Event()
@@ -6471,7 +6480,7 @@ class TestSyncManagerTypes(unittest.TestCase):
 
     def setUp(self):
         self.manager = self.manager_class()
-        with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
             self.manager.start()
         self.proc = None
 
@@ -6521,7 +6530,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.clear()
         obj.wait(0.001)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_event(self):
         o = self.manager.Event()
         o.set()
@@ -6534,7 +6543,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.acquire()
         if sys.hexversion > 0x30e00a6: obj.locked()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_lock(self, lname="Lock"):
         o = getattr(self.manager, lname)()
         self.run_worker(self._test_lock, o)
@@ -6547,7 +6556,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.release()
         if sys.hexversion > 0x30e00a6: obj.locked()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_rlock(self, lname="RLock"):
         o = getattr(self.manager, lname)()
         self.run_worker(self._test_rlock, o)
@@ -6556,7 +6565,7 @@ class TestSyncManagerTypes(unittest.TestCase):
     def _test_semaphore(cls, obj):
         obj.acquire()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_semaphore(self, sname="Semaphore"):
         o = getattr(self.manager, sname)()
         self.run_worker(self._test_semaphore, o)
@@ -6570,7 +6579,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.acquire()
         obj.release()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_condition(self):
         o = self.manager.Condition()
         self.run_worker(self._test_condition, o)
@@ -6580,7 +6589,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         assert obj.parties == 5
         obj.reset()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_barrier(self):
         o = self.manager.Barrier(5)
         self.run_worker(self._test_barrier, o)
@@ -6591,7 +6600,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         with obj:
             pass
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_pool(self):
         o = self.manager.Pool(processes=4)
         self.run_worker(self._test_pool, o)
@@ -6606,7 +6615,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         assert obj.get() == 6
         assert obj.empty()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_queue(self, qname="Queue"):
         o = getattr(self.manager, qname)(2)
         o.put(5)
@@ -6615,7 +6624,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         assert o.empty()
         assert not o.full()
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_joinable_queue(self):
         self.test_queue("JoinableQueue")
 
@@ -6650,7 +6659,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.clear()
         case.assertEqual(len(obj), 0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_list(self):
         o = self.manager.list()
         o.append(5)
@@ -6692,7 +6701,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         obj.clear()
         case.assertEqual(len(obj), 0)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_dict(self):
         o = self.manager.dict()
         o['foo'] = 5
@@ -6707,7 +6716,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         case.assertEqual(obj.get(), 1)
         obj.set(2)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_value(self):
         o = self.manager.Value('i', 1)
         self.run_worker(self._test_value, o)
@@ -6722,7 +6731,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         case.assertEqual(len(obj), 2)
         case.assertListEqual(list(obj), [0, 1])
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_array(self):
         o = self.manager.Array('i', [0, 1])
         self.run_worker(self._test_array, o)
@@ -6733,7 +6742,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         case.assertEqual(obj.x, 0)
         case.assertEqual(obj.y, 1)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_namespace(self):
         o = self.manager.Namespace()
         o.x = 0
@@ -6853,7 +6862,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         case.assertGreater(obj, {'a'})
         case.assertGreaterEqual(obj, {'a', 'b'})
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_set(self):
         o = self.manager.set()
         self.run_worker(self._test_set_operator_symbols, o)
@@ -6871,7 +6880,7 @@ class TestSyncManagerTypes(unittest.TestCase):
         self.assertSetEqual(o, {"a", "b", "c"})
         self.assertRaises(RemoteError, self.manager.set, 1234)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_set_contain_all_method(self):
         o = self.manager.set()
         set_methods = {
@@ -6926,7 +6935,7 @@ class _TestAtExit(BaseTestCase):
                 f.write("deadbeef")
         atexit.register(exit_handler)
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     def test_atexit(self):
         # gh-83856
         with os_helper.temp_dir() as temp_dir:
@@ -7068,7 +7077,7 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual("332833500", out.decode('utf-8').strip())
         self.assertFalse(err, msg=err.decode('utf-8'))
 
-    @warnings_helper.ignore_fork_in_thread_deprecation_warnings()
+    @warnings_helper_ignore_fork_in_thread_deprecation_warnings()
     @unittest.skipIf(sys.hexversion <= 0x30e00b1, "added in 3.14.0b2")
     def test_forked_thread_not_started(self):
         # gh-134381: Ensure that a thread that has not been started yet in
@@ -7204,7 +7213,7 @@ class ManagerMixin(BaseMixin):
 
     @classmethod
     def setUpClass(cls):
-        with warnings_helper.ignore_fork_in_thread_deprecation_warnings():
+        with warnings_helper_ignore_fork_in_thread_deprecation_warnings():
             super().setUpClass()
             cls.manager = multiprocessing.Manager()
 


### PR DESCRIPTION
## Summary
use dummy decorator if `warnings_helper.ignore_fork_in_thread_deprecation_warnings` not found 

FIXME: Need a dummy decorator that can act as a contextmanager in/on a unittest method
